### PR TITLE
plugin-tree / plugin-resolve / plugin-resolve-transitive: Optional key

### DIFF
--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginResolveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginResolveMojo.java
@@ -9,10 +9,14 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 
 import eu.maveniverse.maven.toolbox.plugin.MPPluginMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Output;
+import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.artifact.Artifact;
 
 /**
  * Resolves transitively given project build plugin.
@@ -45,12 +49,16 @@ public class PluginResolveMojo extends MPPluginMojoSupport {
 
     @Override
     protected boolean doExecute(Output output, ToolboxCommando toolboxCommando) throws Exception {
+        Collection<Artifact> roots;
+        ResolutionRoot root = pluginAsResolutionRoot(toolboxCommando, false);
+        if (root != null) {
+            roots = Collections.singleton(root.getArtifact());
+        } else {
+            roots = allPluginsAsResolutionRoots(toolboxCommando).stream()
+                    .map(ResolutionRoot::getArtifact)
+                    .collect(Collectors.toList());
+        }
         return toolboxCommando.resolve(
-                Collections.singleton(pluginAsResolutionRoot(toolboxCommando).getArtifact()),
-                sources,
-                javadoc,
-                signature,
-                toolboxCommando.artifactSink(output, sinkSpec),
-                output);
+                roots, sources, javadoc, signature, toolboxCommando.artifactSink(output, sinkSpec), output);
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginResolveTransitiveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginResolveTransitiveMojo.java
@@ -9,8 +9,10 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 
 import eu.maveniverse.maven.toolbox.plugin.MPPluginMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Output;
+import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import java.util.Collection;
 import java.util.Collections;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -52,9 +54,16 @@ public class PluginResolveTransitiveMojo extends MPPluginMojoSupport {
 
     @Override
     protected boolean doExecute(Output output, ToolboxCommando toolboxCommando) throws Exception {
+        Collection<ResolutionRoot> roots;
+        ResolutionRoot root = pluginAsResolutionRoot(toolboxCommando, false);
+        if (root != null) {
+            roots = Collections.singleton(root);
+        } else {
+            roots = allPluginsAsResolutionRoots(toolboxCommando);
+        }
         return toolboxCommando.resolveTransitive(
                 ResolutionScope.parse(scope),
-                Collections.singleton(pluginAsResolutionRoot(toolboxCommando)),
+                roots,
                 sources,
                 javadoc,
                 signature,

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginTreeMojo.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 
 import eu.maveniverse.maven.toolbox.plugin.MPPluginMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Output;
+import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -33,7 +34,16 @@ public class PluginTreeMojo extends MPPluginMojoSupport {
 
     @Override
     protected boolean doExecute(Output output, ToolboxCommando toolboxCommando) throws Exception {
-        return toolboxCommando.tree(
-                ResolutionScope.parse(scope), pluginAsResolutionRoot(toolboxCommando), verboseTree, output);
+        ResolutionRoot root = pluginAsResolutionRoot(toolboxCommando, false);
+        if (root != null) {
+            return toolboxCommando.tree(ResolutionScope.parse(scope), root, verboseTree, output);
+        } else {
+            boolean result = true;
+            for (ResolutionRoot rersolutionRoot : allPluginsAsResolutionRoots(toolboxCommando)) {
+                result = result
+                        && toolboxCommando.tree(ResolutionScope.parse(scope), rersolutionRoot, verboseTree, output);
+            }
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Make 'pluginKey' parameter optional for the plugin-related mojos where mass operation makes sense:
- plugin-tree
- plugin-resolve
- plugin-resolve-transitive

If 'pluginKey' is not given, all plugins of the project will be considered.