### PR TITLE
Workaround m-p-p issues

### DIFF
--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -24,11 +24,15 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <prerequisites>
-    <maven>3.6.3</maven>
+    <maven>${prerequisiteMaven}</maven>
   </prerequisites>
 
   <properties>
     <mainClass>eu.maveniverse.maven.toolbox.plugin.CLI</mainClass>
+
+    <!-- m-p-p workarounds -->
+    <prerequisiteMaven>3.6.3</prerequisiteMaven>
+    <prerequisiteJava>${maven.compiler.release}</prerequisiteJava>
   </properties>
 
   <dependencies>
@@ -178,6 +182,8 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <goalPrefix>toolbox</goalPrefix>
+          <requiredMavenVersion>${prerequisiteMaven}</requiredMavenVersion>
+          <requiredJavaVersion>${prerequisiteJava}</requiredJavaVersion>
           <expectedProvidedScopeExclusions>
             <!-- Is needed in compile scope to have it included in CLI Uber JAR as well -->
             <expectedProvidedScopeExclusion>org.apache.maven:maven-plugin-api</expectedProvidedScopeExclusion>


### PR DESCRIPTION
Otherwise it auto-detects prerequisites as:
* maven: 3.9.6 (due API use)
* Java: 22 (due JLine3 use)