### PR TITLE
Uber should NOT be used in Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
       </dependency>
       <dependency>
         <groupId>eu.maveniverse.maven.mima.runtime</groupId>
-        <artifactId>standalone-static-uber</artifactId>
+        <artifactId>standalone-static</artifactId>
         <version>${version.mima}</version>
       </dependency>
 

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -97,7 +97,7 @@
     </dependency>
     <dependency>
       <groupId>eu.maveniverse.maven.mima.runtime</groupId>
-      <artifactId>standalone-static-uber</artifactId>
+      <artifactId>standalone-static</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>eu.maveniverse.maven.mima.runtime</groupId>
-      <artifactId>standalone-static-uber</artifactId>
+      <artifactId>standalone-static</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
As Maven Core cannot filter out then (probably
incompatible) Resolver classes.