### PR TITLE
Libyear command

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -190,4 +190,14 @@ public interface ToolboxCommando {
     boolean search(RemoteRepository remoteRepository, String expression, Output output) throws IOException;
 
     boolean verify(RemoteRepository remoteRepository, String gav, String sha1, Output output) throws IOException;
+
+    // Various
+
+    boolean libYear(
+            ResolutionScope resolutionScope,
+            Collection<ResolutionRoot> resolutionRoots,
+            boolean quiet,
+            boolean allowSnapshots,
+            Output output)
+            throws Exception;
 }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.shared.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.toolbox.shared.ArtifactSink;
+import eu.maveniverse.maven.toolbox.shared.Output;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import org.apache.maven.search.api.SearchBackend;
+import org.apache.maven.search.api.SearchRequest;
+import org.apache.maven.search.api.SearchResponse;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.eclipse.aether.version.Version;
+
+/**
+ * Construction to calculate "libyear".
+ *
+ * @see <a href="https://libyear.com/">libyear</a>
+ */
+public final class LibYearSink implements ArtifactSink {
+    public static final class LibYear {
+        private final String currentVersion;
+        private final Instant currentVersionInstant;
+        private final String latestVersion;
+        private final Instant latestVersionInstant;
+
+        private LibYear(
+                String currentVersion,
+                Instant currentVersionInstant,
+                String latestVersion,
+                Instant latestVersionInstant) {
+            this.currentVersion = currentVersion;
+            this.currentVersionInstant = currentVersionInstant;
+            this.latestVersion = latestVersion;
+            this.latestVersionInstant = latestVersionInstant;
+        }
+
+        public String getCurrentVersion() {
+            return currentVersion;
+        }
+
+        public Instant getCurrentVersionInstant() {
+            return currentVersionInstant;
+        }
+
+        public String getLatestVersion() {
+            return latestVersion;
+        }
+
+        public Instant getLatestVersionInstant() {
+            return latestVersionInstant;
+        }
+    }
+
+    /**
+     * Creates libYear sink.
+     */
+    public static LibYearSink libYear(
+            Output output,
+            Context context,
+            ToolboxResolverImpl toolboxResolver,
+            ToolboxSearchApiImpl toolboxSearchApi,
+            boolean quiet,
+            boolean allowSnapshots,
+            BiFunction<Artifact, List<Version>, Version> versionSelector) {
+        return new LibYearSink(
+                output, context, toolboxResolver, toolboxSearchApi, quiet, allowSnapshots, versionSelector);
+    }
+
+    private final Output output;
+    private final Context context;
+    private final ToolboxResolverImpl toolboxResolver;
+    private final ToolboxSearchApiImpl toolboxSearchApi;
+    private final boolean quiet;
+    private final boolean allowSnapshots;
+    private final BiFunction<Artifact, List<Version>, Version> versionSelector;
+    private final ConcurrentMap<Artifact, LibYear> libYear;
+
+    private LibYearSink(
+            Output output,
+            Context context,
+            ToolboxResolverImpl toolboxResolver,
+            ToolboxSearchApiImpl toolboxSearchApi,
+            boolean quiet,
+            boolean allowSnapshots,
+            BiFunction<Artifact, List<Version>, Version> versionSelector) {
+        this.output = requireNonNull(output, "output");
+        this.context = requireNonNull(context, "context");
+        this.toolboxResolver = requireNonNull(toolboxResolver, "toolboxResolver");
+        this.toolboxSearchApi = requireNonNull(toolboxSearchApi, "toolboxSearchApi");
+        this.quiet = quiet;
+        this.allowSnapshots = allowSnapshots;
+        this.versionSelector = requireNonNull(versionSelector);
+        this.libYear = new ConcurrentHashMap<>();
+    }
+
+    public Map<Artifact, LibYear> getLibYear() {
+        return libYear;
+    }
+
+    @Override
+    public void accept(Artifact artifact) throws IOException {
+        requireNonNull(artifact, "artifact");
+        libYear.computeIfAbsent(artifact, a -> {
+            try {
+                String currentVersion = artifact.getVersion();
+                Instant currentVersionInstant = artifactPublishDate(artifact);
+                String latestVersion = currentVersion;
+                Instant latestVersionInstant = null;
+                latestVersion = versionSelector
+                        .apply(artifact, toolboxResolver.findNewerVersions(artifact, allowSnapshots))
+                        .toString();
+                latestVersionInstant = artifactPublishDate(artifact.setVersion(latestVersion));
+                return new LibYear(currentVersion, currentVersionInstant, latestVersion, latestVersionInstant);
+            } catch (IOException | VersionRangeResolutionException e) {
+                // ignore
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void close() throws DeploymentException {
+        float totalLibYears = 0;
+        int outdated = 0;
+        String indent = "-> ";
+        if (!quiet) {
+            output.normal("{}------------------------------", indent);
+            for (Map.Entry<Artifact, LibYear> entry : getLibYear().entrySet()) {
+                String line = "";
+                if (entry.getValue() != null) {
+                    LibYear value = entry.getValue();
+                    if (Objects.equals(value.getCurrentVersion(), value.getLatestVersion())) {
+                        continue;
+                    }
+                    outdated++;
+
+                    LocalDate currentVersionDate = value.getCurrentVersionInstant() != null
+                            ? value.getCurrentVersionInstant()
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
+                            : null;
+                    LocalDate latestVersionDate = value.getLatestVersionInstant() != null
+                            ? value.getLatestVersionInstant()
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
+                            : null;
+
+                    if (currentVersionDate != null && latestVersionDate != null) {
+                        long libWeeksOutdated = ChronoUnit.WEEKS.between(currentVersionDate, latestVersionDate);
+                        float libYearsOutdated = libWeeksOutdated / 52f;
+                        totalLibYears += libYearsOutdated;
+                        line = String.format(
+                                "%.2f years from %s %s (%s) => %s (%s)",
+                                libYearsOutdated,
+                                ArtifactIdUtils.toVersionlessId(entry.getKey()),
+                                value.getCurrentVersion(),
+                                currentVersionDate,
+                                value.getLatestVersion(),
+                                latestVersionDate);
+                    } else {
+                        line = String.format(
+                                "%s %s (?) => %s (?)",
+                                ArtifactIdUtils.toVersionlessId(entry.getKey()),
+                                value.getCurrentVersion(),
+                                value.getLatestVersion());
+                    }
+                } else {
+                    line = entry.getKey() + " ?";
+                }
+                output.normal("{}{}", indent, line);
+            }
+        }
+        output.normal("{}------------------------------", indent);
+        output.normal(
+                "{} Total of {} years from {} dependencies", indent, String.format("%.2f", totalLibYears), outdated);
+        output.normal("{}------------------------------", indent);
+    }
+
+    private Instant artifactPublishDate(Artifact artifact) throws IOException {
+        for (RemoteRepository remoteRepository : context.remoteRepositories()) {
+            try (SearchBackend backend = toolboxSearchApi.getSmoBackend(remoteRepository)) {
+                SearchRequest searchRequest = new SearchRequest(toolboxSearchApi.toSmoQuery(artifact));
+                SearchResponse searchResponse = backend.search(searchRequest);
+                if (searchResponse.getCurrentHits() > 0) {
+                    Long lastUpdated =
+                            searchResponse.getPage().iterator().next().getLastUpdated();
+                    if (lastUpdated != null) {
+                        return Instant.ofEpochMilli(lastUpdated);
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                // most likely not SMO service (remote repo is not CENTRAL); ignore
+            }
+        }
+        return null;
+    }
+}

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
@@ -194,8 +194,7 @@ public final class LibYearSink implements ArtifactSink {
             }
         }
 
-        String indent = "  ";
-        output.normal("{}", indent);
+        String indent = "";
         output.normal("{}Outdated versions with known age", indent);
         timedOnes.forEach(l -> output.normal("{}{}", indent, l));
         output.normal("{}", indent);

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxResolverImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxResolverImpl.java
@@ -372,6 +372,31 @@ public class ToolboxResolverImpl {
         }
     }
 
+    public List<Version> findNewerVersions(Artifact artifact, boolean allowSnapshots)
+            throws VersionRangeResolutionException {
+        VersionRangeRequest rangeRequest = new VersionRangeRequest();
+        rangeRequest.setArtifact(new DefaultArtifact(
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getClassifier(),
+                artifact.getExtension(),
+                artifact.getVersion().contains(",") ? artifact.getVersion() : "[" + artifact.getVersion() + ",)"));
+        rangeRequest.setRepositories(remoteRepositories);
+        rangeRequest.setRequestContext(CTX_TOOLBOX);
+        VersionRangeResult result = repositorySystem.resolveVersionRange(session, rangeRequest);
+        if (allowSnapshots) {
+            return result.getVersions();
+        } else {
+            ArrayList<Version> versions = new ArrayList<>(result.getVersions().size());
+            for (Version version : result.getVersions()) {
+                if (!version.toString().endsWith("SNAPSHOT")) {
+                    versions.add(version);
+                }
+            }
+            return versions;
+        }
+    }
+
     public List<Artifact> listAvailablePlugins(Collection<String> groupIds) throws Exception {
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(this.session);
         session.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_ALWAYS);

--- a/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImplTest.java
+++ b/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImplTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.shared.internal;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.Runtime;
+import eu.maveniverse.maven.mima.context.Runtimes;
+import eu.maveniverse.maven.toolbox.shared.NullOutput;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+public class ToolboxCommandoImplTest {
+    @Test
+    void search() throws IOException {
+        Runtime runtime = Runtimes.INSTANCE.getRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withBasedirOverride(Paths.get("target").toAbsolutePath())
+                .build())) {
+            ToolboxCommandoImpl tc = new ToolboxCommandoImpl(runtime, context);
+
+            tc.search(ContextOverrides.CENTRAL, "junit:junit:4.13.2", new NullOutput());
+        }
+    }
+}

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/CLI.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/CLI.java
@@ -28,6 +28,7 @@ import picocli.CommandLine;
             GavExistsMojo.class,
             GavIdentifyMojo.class,
             GavInstallMojo.class,
+            GavLibYearMojo.class,
             GavListAvailablePluginsMojo.class,
             GavListMojo.class,
             GavListRepositoriesMojo.class,

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.plugin.gav;
+
+import eu.maveniverse.maven.toolbox.plugin.GavSearchMojoSupport;
+import eu.maveniverse.maven.toolbox.shared.Output;
+import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
+import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import picocli.CommandLine;
+
+/**
+ * Calculates "libyear" for Maven Artifacts transitively.
+ */
+@CommandLine.Command(name = "libyear", description = "Calculates libyear for artifacts.")
+@Mojo(name = "gav-libyear", requiresProject = false, threadSafe = true)
+public class GavLibYearMojo extends GavSearchMojoSupport {
+    /**
+     * The comma separated GAVs to "libyear".
+     */
+    @CommandLine.Parameters(index = "0", description = "The comma separated GAVs to resolve", arity = "1")
+    @Parameter(property = "gav", required = true)
+    private String gav;
+
+    /**
+     * Resolution scope to resolve (default 'runtime').
+     */
+    @CommandLine.Option(
+            names = {"--scope"},
+            defaultValue = "runtime",
+            description = "Resolution scope to resolve (default 'runtime')")
+    @Parameter(property = "scope", defaultValue = "runtime", required = true)
+    private String scope;
+
+    /**
+     * Comma separated list of BOMs to apply.
+     */
+    @CommandLine.Option(
+            names = {"--boms"},
+            defaultValue = "",
+            description = "Comma separated list of BOMs to apply")
+    @Parameter(property = "boms")
+    private String boms;
+
+    @Override
+    protected boolean doExecute(Output output, ToolboxCommando toolboxCommando) throws Exception {
+        return toolboxCommando.libYear(
+                ResolutionScope.parse(scope), toolboxCommando.loadGavs(slurp(gav), slurp(boms)), false, false, output);
+    }
+}


### PR DESCRIPTION
See https://libyear.com/

Example:
```
[cstamas@angeleyes toolbox (libyear)]$ java -jar toolbox/target/toolbox-0.1.11-SNAPSHOT-cli.jar libyear org.apache.maven:maven-core:3.9.6
Outdated versions with known age
4.17 years from org.codehaus.plexus:plexus-component-annotations:jar 2.1.0 (2019-10-23) => 2.2.0 (2023-12-24)
2.73 years from org.apache.commons:commons-lang3:jar 3.12.0 (2021-02-26) => 3.14.0 (2023-11-18)
2.12 years from org.codehaus.plexus:plexus-cipher:jar 2.0 (2021-09-08) => 2.1.0 (2023-10-22)
2.04 years from org.apache.maven.shared:maven-shared-utils:jar 3.3.4 (2021-04-26) => 3.4.2 (2023-05-11)
1.90 years from org.slf4j:slf4j-api:jar 1.7.36 (2022-02-08) => 2.1.0-alpha1 (2024-01-02)
1.29 years from com.google.inject:guice:jar 5.1.0 (2022-01-24) => 7.0.0 (2023-05-12)
1.12 years from org.codehaus.plexus:plexus-utils:jar 3.5.1 (2023-03-02) => 4.0.1 (2024-04-13)
0.42 years from org.apache.maven.resolver:maven-resolver-util:jar 1.9.18 (2023-11-22) => 2.0.0-alpha-11 (2024-04-26)
0.42 years from org.apache.maven.resolver:maven-resolver-spi:jar 1.9.18 (2023-11-22) => 2.0.0-alpha-11 (2024-04-26)
0.42 years from org.apache.maven.resolver:maven-resolver-named-locks:jar 1.9.18 (2023-11-22) => 2.0.0-alpha-11 (2024-04-26)
0.42 years from org.apache.maven.resolver:maven-resolver-impl:jar 1.9.18 (2023-11-22) => 2.0.0-alpha-11 (2024-04-26)
0.42 years from org.apache.maven.resolver:maven-resolver-api:jar 1.9.18 (2023-11-22) => 2.0.0-alpha-11 (2024-04-26)
0.27 years from org.apache.maven:maven-settings:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-settings-builder:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-resolver-provider:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-repository-metadata:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-plugin-api:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-model:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-model-builder:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-core:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-builder-support:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)
0.27 years from org.apache.maven:maven-artifact:jar 3.9.6 (2023-11-28) => 4.0.0-alpha-13 (2024-03-06)

Outdated versions
com.google.guava:failureaccess:jar 1.0.1 (?) => 1.0.2 (?)
com.google.guava:guava:jar 32.0.1-jre (?) => 33.2.0-jre (?)
org.codehaus.plexus:plexus-classworlds:jar 2.7.0 (?) => 2.8.0 (?)
org.codehaus.plexus:plexus-interpolation:jar 1.26 (?) => 1.27 (?)

Total of 20.17 years from 26 outdated dependencies

[cstamas@angeleyes toolbox (libyear)]$ 
```