### PR TITLE
libyear: align with other implementation

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -201,6 +201,7 @@ public interface ToolboxCommando {
     boolean libYear(
             ResolutionScope resolutionScope,
             Collection<ResolutionRoot> resolutionRoots,
+            boolean transitive,
             boolean quiet,
             boolean allowSnapshots,
             ArtifactVersionSelector artifactVersionSelector,

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
@@ -166,6 +166,9 @@ public final class LibYearSink implements ArtifactSink {
                                 : null;
 
                         if (currentVersionDate != null && latestVersionDate != null) {
+                            if (currentVersionDate.isAfter(latestVersionDate)) {
+                                continue;
+                            }
                             long libWeeksOutdated = ChronoUnit.WEEKS.between(currentVersionDate, latestVersionDate);
                             if (libWeeksOutdated < 0) {
                                 continue;
@@ -210,7 +213,7 @@ public final class LibYearSink implements ArtifactSink {
                     "{}Total of {} years from {} outdated dependencies",
                     indent,
                     String.format("%.2f", totalLibYears),
-                    withLibyear.size() + withoutLibyear.size());
+                    withLibyear.values().stream().mapToInt(List::size).sum() + withoutLibyear.size());
         } finally {
             searchBackends.forEach(b -> {
                 try {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
@@ -16,7 +16,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import picocli.CommandLine;
 
 /**
- * Calculates "libyear" for Maven Artifacts transitively.
+ * Calculates "libyear" for Maven Artifacts (for direct dependencies or transitively).
  */
 @CommandLine.Command(name = "libyear", description = "Calculates libyear for artifacts.")
 @Mojo(name = "gav-libyear", requiresProject = false, threadSafe = true)
@@ -29,13 +29,13 @@ public class GavLibYearMojo extends GavSearchMojoSupport {
     private String gav;
 
     /**
-     * Resolution scope to resolve (default 'runtime').
+     * Resolution scope to resolve (default 'test').
      */
     @CommandLine.Option(
             names = {"--scope"},
-            defaultValue = "runtime",
-            description = "Resolution scope to resolve (default 'runtime')")
-    @Parameter(property = "scope", defaultValue = "runtime", required = true)
+            defaultValue = "test",
+            description = "Resolution scope to resolve (default 'test')")
+    @Parameter(property = "scope", defaultValue = "test", required = true)
     private String scope;
 
     /**
@@ -57,6 +57,15 @@ public class GavLibYearMojo extends GavSearchMojoSupport {
             description = "Artifact version selector spec")
     @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
     private String artifactVersionSelectorSpec;
+
+    /**
+     * Make libyear transitive, in which case it will calculate for whole transitive hull.
+     */
+    @CommandLine.Option(
+            names = {"--transitive"},
+            description = "Make command transitive")
+    @Parameter(property = "transitive", defaultValue = "false")
+    private boolean transitive;
 
     /**
      * Make libyear quiet.
@@ -81,6 +90,7 @@ public class GavLibYearMojo extends GavSearchMojoSupport {
         return toolboxCommando.libYear(
                 ResolutionScope.parse(scope),
                 toolboxCommando.loadGavs(slurp(gav), slurp(boms)),
+                transitive,
                 quiet,
                 allowSnapshots,
                 toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec),

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
@@ -15,14 +15,14 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Calculates "libyear" for Maven project transitively.
+ * Calculates "libyear" for Maven Projects (for direct dependencies or transitively).
  */
 @Mojo(name = "libyear", threadSafe = true)
 public class LibYearMojo extends MPMojoSupport {
     /**
-     * Resolution scope to resolve (default 'runtime').
+     * Resolution scope to resolve (default 'test').
      */
-    @Parameter(property = "scope", defaultValue = "runtime", required = true)
+    @Parameter(property = "scope", defaultValue = "test", required = true)
     private String scope;
 
     /**
@@ -36,6 +36,12 @@ public class LibYearMojo extends MPMojoSupport {
      */
     @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
     private String artifactVersionSelectorSpec;
+
+    /**
+     * Make libyear transitive, in which case it will calculate it for whole transitive hull.
+     */
+    @Parameter(property = "transitive", defaultValue = "false")
+    private boolean transitive;
 
     /**
      * Make libyear quiet.
@@ -56,6 +62,7 @@ public class LibYearMojo extends MPMojoSupport {
                 resolutionScope,
                 projectDependenciesAsResolutionRoots(
                         resolutionScope, toolboxCommando.parseDependencyMatcherSpec(depSpec)),
+                transitive,
                 quiet,
                 allowSnapshots,
                 toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec),


### PR DESCRIPTION
Seems it makes sense to make it by default non-transitive. Also, do not use negative weeks but timestamps to eliminate.

Now it does this:

```
[cstamas@angeleyes maven (master)]$ mvn io.github.mfoo:libyear-maven-plugin:analyze -f maven-core
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------< org.apache.maven:maven-core >---------------------
[INFO] Building Maven Core 4.0.0-beta-3-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- libyear:1.1.0:analyze (default-cli) @ maven-core ---
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   com.google.inject:guice ................................ 0.00 libyears
[INFO]   commons-io:commons-io .................................. 2.73 libyears
[INFO]   org.codehaus.plexus:plexus-classworlds ................. 5.00 libyears
[INFO]   org.codehaus.plexus:plexus-testing ..................... 2.54 libyears
[INFO]   org.junit.jupiter:junit-jupiter-api .................... 0.46 libyears
[INFO]   org.junit.jupiter:junit-jupiter-params ................. 0.46 libyears
[INFO]   org.mockito:mockito-junit-jupiter ...................... 0.52 libyears
[INFO] 
[INFO] This module is 11.71 libyears behind
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.726 s
[INFO] Finished at: 2024-05-17T10:40:57+02:00
[INFO] ------------------------------------------------------------------------
[cstamas@angeleyes maven (master)]$ mvn eu.maveniverse.maven.plugins:toolbox:0.1.16-SNAPSHOT:libyear -f maven-core/ -Dtransitive=false
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------< org.apache.maven:maven-core >---------------------
[INFO] Building Maven Core 4.0.0-beta-3-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- toolbox:0.1.16-SNAPSHOT:libyear (default-cli) @ maven-core ---
[INFO] Outdated versions with known age
[INFO] 5.00 years from org.codehaus.plexus:plexus-classworlds:jar 2.6.0 (2018-12-28) => 2.8.0 (2023-12-23)
[INFO] 2.73 years from commons-io:commons-io:jar 2.11.0 (2021-07-10) => 2.16.1 (2024-04-05)
[INFO] 2.54 years from org.codehaus.plexus:plexus-testing:jar 1.0.0 (2021-05-28) => 1.3.0 (2023-12-14)
[INFO] 0.52 years from org.mockito:mockito-junit-jupiter:jar 5.7.0 (2023-11-02) => 5.12.0 (2024-05-11)
[INFO] 0.46 years from org.junit.jupiter:junit-jupiter-api:jar 5.10.1 (2023-11-05) => 5.11.0-M1 (2024-04-23)
[INFO] 0.46 years from org.junit.jupiter:junit-jupiter-params:jar 5.10.1 (2023-11-05) => 5.11.0-M1 (2024-04-23)
[INFO] 
[INFO] 
[INFO] Total of 11.71 years from 6 outdated dependencies
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.662 s
[INFO] Finished at: 2024-05-17T10:41:09+02:00
[INFO] ------------------------------------------------------------------------
[cstamas@angeleyes maven (master)]$ 
```