### PR TITLE
Improve ArtifactVersionSelectors

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelector.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelector.java
@@ -127,7 +127,7 @@ public interface ArtifactVersionSelector extends BiFunction<Artifact, List<Versi
      *
      * @see <a href="https://maven.apache.org/resolver-archives/resolver-2.0.0-alpha-11/apidocs/org/eclipse/aether/util/version/package-summary.html">Resolver Generic Version spec</a>
      */
-    private static boolean isPreviewVersion(String version) {
+    static boolean isPreviewVersion(String version) {
         // most trivial "preview" version is 'a1'
         if (version.length() > 1) {
             String ver = version.toLowerCase(Locale.ENGLISH);

--- a/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelectorTest.java
+++ b/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelectorTest.java
@@ -31,8 +31,15 @@ public class ArtifactVersionSelectorTest {
         }
     }
 
-    private final List<Version> versions =
-            Arrays.asList(version("2.0.0"), version("3.0.1"), version("3.1.0"), version("4.0.0"));
+    private final List<Version> versions = Arrays.asList(
+            version("2.0.0"),
+            version("3.0.1"),
+            version("3.0.2-alpha"),
+            version("3.1.0M1"),
+            version("3.1.0"),
+            version("3.1.1M1"),
+            version("4.0.0RC"),
+            version("4.0.0"));
 
     @Test
     void identity() {
@@ -50,16 +57,40 @@ public class ArtifactVersionSelectorTest {
 
     @Test
     void sameMajor() {
-        assertEquals("3.1.0", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:3.0.0"), versions));
+        assertEquals("3.1.1M1", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:3.0.0"), versions));
         assertEquals(
                 "v1", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
     }
 
     @Test
     void sameMinor() {
-        assertEquals("3.0.1", ArtifactVersionSelector.minor().apply(new DefaultArtifact("g:a:3.0.0"), versions));
+        assertEquals("3.0.2-alpha", ArtifactVersionSelector.minor().apply(new DefaultArtifact("g:a:3.0.0"), versions));
         assertEquals(
                 "v1", ArtifactVersionSelector.minor().apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
+    }
+
+    @Test
+    void sameMajorNoPreviews() {
+        assertEquals(
+                "3.1.0",
+                ArtifactVersionSelector.noPreviews(ArtifactVersionSelector.major())
+                        .apply(new DefaultArtifact("g:a:3.0.0"), versions));
+        assertEquals(
+                "v1",
+                ArtifactVersionSelector.noPreviews(ArtifactVersionSelector.major())
+                        .apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
+    }
+
+    @Test
+    void sameMinorNoPreviews() {
+        assertEquals(
+                "3.0.1",
+                ArtifactVersionSelector.noPreviews(ArtifactVersionSelector.minor())
+                        .apply(new DefaultArtifact("g:a:3.0.0"), versions));
+        assertEquals(
+                "v1",
+                ArtifactVersionSelector.noPreviews(ArtifactVersionSelector.minor())
+                        .apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
     }
 
     @Test
@@ -74,10 +105,18 @@ public class ArtifactVersionSelectorTest {
                 "4.0.0",
                 ArtifactVersionSelector.build(Collections.emptyMap(), "last()").apply(artifact, versions));
         assertEquals(
-                "3.1.0",
+                "3.1.1M1",
                 ArtifactVersionSelector.build(Collections.emptyMap(), "major()").apply(artifact, versions));
         assertEquals(
-                "3.0.1",
+                "3.0.2-alpha",
                 ArtifactVersionSelector.build(Collections.emptyMap(), "minor()").apply(artifact, versions));
+        assertEquals(
+                "3.1.0",
+                ArtifactVersionSelector.build(Collections.emptyMap(), "noPreviews(major())")
+                        .apply(artifact, versions));
+        assertEquals(
+                "3.0.1",
+                ArtifactVersionSelector.build(Collections.emptyMap(), "noPreviews(minor())")
+                        .apply(artifact, versions));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
@@ -49,13 +49,13 @@ public class GavLibYearMojo extends GavSearchMojoSupport {
     private String boms;
 
     /**
-     * Artifact version selector spec string.
+     * Artifact version selector spec string, default is 'noPreviews(major())'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "major()",
-            description = "Artifact version selector spec")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
+            defaultValue = "noPreviews(major())",
+            description = "Artifact version selector spec (default 'noPreviews(major())')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "noPreviews(major())")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
@@ -32,9 +32,9 @@ public class LibYearMojo extends MPMojoSupport {
     private String depSpec;
 
     /**
-     * Artifact version selector spec.
+     * Artifact version selector spec (default is 'noPreviews(major())').
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "noPreviews(major())")
     private String artifactVersionSelectorSpec;
 
     /**


### PR DESCRIPTION
Introduce `noPreviews(delegate)` op. 

Also, in libyear make default `noPreviews(major())`.