### PR TITLE
Add auth and proxy support for Search RR

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/Java11HttpClientFactory.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/Java11HttpClientFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.toolbox.shared.internal;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.HashMap;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Java 11 {@link HttpClient} factory that creates pre-configured HTTP client based on Resolver {@link RemoteRepository}.
+ */
+public final class Java11HttpClientFactory {
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10L);
+
+    public static HttpClient buildHttpClient(RepositorySystemSession session, RemoteRepository repository) {
+        return buildHttpClient(DEFAULT_TIMEOUT, session, repository);
+    }
+
+    private static HttpClient buildHttpClient(
+            Duration timeout, RepositorySystemSession session, RemoteRepository repository) {
+
+        HttpClient.Builder builder =
+                HttpClient.newBuilder().connectTimeout(timeout).followRedirects(HttpClient.Redirect.NEVER);
+
+        HashMap<Authenticator.RequestorType, PasswordAuthentication> authentications = new HashMap<>();
+        try (AuthenticationContext repoAuthContext = AuthenticationContext.forRepository(session, repository)) {
+            if (repoAuthContext != null) {
+                authentications.put(
+                        Authenticator.RequestorType.SERVER,
+                        new PasswordAuthentication(
+                                repoAuthContext.get(AuthenticationContext.USERNAME),
+                                repoAuthContext
+                                        .get(AuthenticationContext.USERNAME)
+                                        .toCharArray()));
+            }
+        }
+        if (repository.getProxy() != null) {
+            builder.proxy(ProxySelector.of(new InetSocketAddress(
+                    repository.getProxy().getHost(), repository.getProxy().getPort())));
+            try (AuthenticationContext proxyAuthContext = AuthenticationContext.forProxy(session, repository)) {
+                if (proxyAuthContext != null) {
+                    authentications.put(
+                            Authenticator.RequestorType.PROXY,
+                            new PasswordAuthentication(
+                                    proxyAuthContext.get(AuthenticationContext.USERNAME),
+                                    proxyAuthContext
+                                            .get(AuthenticationContext.PASSWORD)
+                                            .toCharArray()));
+                }
+            }
+        }
+        if (!authentications.isEmpty()) {
+            builder.authenticator(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return authentications.get(getRequestorType());
+                }
+            });
+        }
+
+        return builder.build();
+    }
+}

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/LibYearSink.java
@@ -113,7 +113,8 @@ public final class LibYearSink implements ArtifactSink {
         this.searchBackends = new ArrayList<>();
         for (RemoteRepository remoteRepository : context.remoteRepositories()) {
             try {
-                this.searchBackends.add(toolboxSearchApi.getRemoteRepositoryBackend(remoteRepository));
+                this.searchBackends.add(toolboxSearchApi.getRemoteRepositoryBackend(
+                        context.repositorySystemSession(), remoteRepository));
             } catch (IllegalArgumentException e) {
                 // most likely cannot figure out what extractor to use; ignore
             }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -541,7 +541,7 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
         }
     }
 
-    private boolean doResolveTransitive(
+    private void doResolveTransitive(
             ResolutionScope resolutionScope,
             ResolutionRoot resolutionRoot,
             boolean sources,
@@ -603,7 +603,6 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
                 }
             }
         }
-        return true;
     }
 
     @Override
@@ -687,7 +686,8 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
             throws IOException {
         ArrayList<Artifact> missingOnes = new ArrayList<>();
         ArrayList<Artifact> existingOnes = new ArrayList<>();
-        try (SearchBackend backend = toolboxSearchApi.getRemoteRepositoryBackend(remoteRepository)) {
+        try (SearchBackend backend =
+                toolboxSearchApi.getRemoteRepositoryBackend(context.repositorySystemSession(), remoteRepository)) {
             Artifact artifact = new DefaultArtifact(gav);
             boolean exists = toolboxSearchApi.exists(backend, artifact);
             if (!exists) {
@@ -770,7 +770,8 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
             sha1 = target;
         }
         output.verbose("Identifying artifact with SHA1={}", sha1);
-        try (SearchBackend backend = toolboxSearchApi.getSmoBackend(remoteRepository)) {
+        try (SearchBackend backend =
+                toolboxSearchApi.getSmoBackend(context.repositorySystemSession(), remoteRepository)) {
             SearchRequest searchRequest = new SearchRequest(fieldQuery(MAVEN.SHA1, sha1));
             SearchResponse searchResponse = backend.search(searchRequest);
 
@@ -786,7 +787,8 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
 
     @Override
     public boolean list(RemoteRepository remoteRepository, String gavoid, Output output) throws IOException {
-        try (SearchBackend backend = toolboxSearchApi.getRemoteRepositoryBackend(remoteRepository)) {
+        try (SearchBackend backend =
+                toolboxSearchApi.getRemoteRepositoryBackend(context.repositorySystemSession(), remoteRepository)) {
             String[] elements = gavoid.split(":");
             if (elements.length < 1 || elements.length > 3) {
                 throw new IllegalArgumentException("Invalid gavoid");
@@ -828,7 +830,8 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
 
     @Override
     public boolean search(RemoteRepository remoteRepository, String expression, Output output) throws IOException {
-        try (SearchBackend backend = toolboxSearchApi.getSmoBackend(remoteRepository)) {
+        try (SearchBackend backend =
+                toolboxSearchApi.getSmoBackend(context.repositorySystemSession(), remoteRepository)) {
             Query query;
             try {
                 query = toolboxSearchApi.toSmoQuery(new DefaultArtifact(expression));
@@ -851,7 +854,8 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
     @Override
     public boolean verify(RemoteRepository remoteRepository, String gav, String sha1, Output output)
             throws IOException {
-        try (SearchBackend backend = toolboxSearchApi.getRemoteRepositoryBackend(remoteRepository)) {
+        try (SearchBackend backend =
+                toolboxSearchApi.getRemoteRepositoryBackend(context.repositorySystemSession(), remoteRepository)) {
             Artifact artifact = new DefaultArtifact(gav);
             boolean verified = toolboxSearchApi.verify(backend, new DefaultArtifact(gav), sha1);
             output.normal("Artifact SHA1({})={}: {}", artifact, sha1, verified ? "MATCHED" : "NOT MATCHED");


### PR DESCRIPTION
Adds HTTP Auth and HTTP proxy support for Search API SMO and RR backends. This is just "basic" support, that can be improved with "real" config coming from session. For now keep it simple.