### PR TITLE
Buildtime and runtime requirement changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     with:
       maven-single-run: false
       maven-matrix: '[ "3.8.8", "3.9.8", "4.0.0-beta-3" ]'
-      jdk-matrix: '[ "17", "21" ]'
+      jdk-matrix: '[ "21" ]'
       maven-test: './mvnw clean verify -e -B -V -P run-its'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     uses: maveniverse/parent/.github/workflows/ci.yml@release-16
     with:
       maven-single-run: false
-      maven-matrix: '[ "3.8.8", "3.9.8", "4.0.0-beta-3" ]'
+      maven-matrix: '[ "3.9.8", "4.0.0-beta-3" ]'
       jdk-matrix: '[ "21" ]'
       maven-test: './mvnw clean verify -e -B -V -P run-its'
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,13 @@
     <project.build.outputTimestamp>2024-08-14T07:51:54Z</project.build.outputTimestamp>
 
     <!--
-    Build time: latest Maven and LTS Java.
+    Build time: latest stable Maven and latest Java LTS.
+    Run time: "not so old" Maven (3.6.3+) and latest Java LTS.
     -->
     <maven.compiler.release>21</maven.compiler.release>
-    <requireBuildtimeMavenVersion.version>[3.9.8,)</requireBuildtimeMavenVersion.version>
     <requireBuildtimeJavaVersion.version>[21.0.3,)</requireBuildtimeJavaVersion.version>
+    <requireBuildtimeMavenVersion.version>[3.9.8,)</requireBuildtimeMavenVersion.version>
+    <requireRuntimeMavenVersion.version>[3.6.3,)</requireRuntimeMavenVersion.version>
 
     <!-- Dependency versions -->
     <version.mima>2.4.15</version.mima>

--- a/pom.xml
+++ b/pom.xml
@@ -59,14 +59,12 @@
   <properties>
     <project.build.outputTimestamp>2024-08-09T16:22:56Z</project.build.outputTimestamp>
 
-    <!-- Maven Indexer needs 11+ -->
-    <maven.compiler.release>11</maven.compiler.release>
-
     <!--
     Build time: latest Maven and LTS Java.
     -->
-    <requireBuildtimeMavenVersion.version>[3.6.3,)</requireBuildtimeMavenVersion.version>
-    <requireBuildtimeJavaVersion.version>[11.0.2,)</requireBuildtimeJavaVersion.version>
+    <maven.compiler.release>21</maven.compiler.release>
+    <requireBuildtimeMavenVersion.version>[3.9.8,)</requireBuildtimeMavenVersion.version>
+    <requireBuildtimeJavaVersion.version>[21.0.3,)</requireBuildtimeJavaVersion.version>
 
     <!-- Dependency versions -->
     <version.mima>2.4.15</version.mima>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -31,7 +31,7 @@
     <mainClass>eu.maveniverse.maven.toolbox.plugin.CLI</mainClass>
 
     <!-- m-p-p workarounds -->
-    <prerequisiteMaven>3.6.3</prerequisiteMaven>
+    <prerequisiteMaven>${requireRuntimeMavenVersion.version}</prerequisiteMaven>
     <prerequisiteJava>${maven.compiler.release}</prerequisiteJava>
   </properties>
 


### PR DESCRIPTION
Buildtime and runtime requirement changes for Maveniverse Toolbox:

Build time:
* latest stable Maven (currently 3.9.8)
* latest Java LTS (currently 21)

Run time CLI:
* latest Java LTS

Run time Maven plugin:
* latest Java LTS
* "not so old" stable Maven (3.6.3+)