### PR TITLE
Fix dump

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/Slf4jOutput.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/Slf4jOutput.java
@@ -16,14 +16,16 @@ import org.slf4j.Logger;
  */
 public final class Slf4jOutput implements Output {
     private final Logger logger;
+    private final boolean verbose;
 
-    public Slf4jOutput(Logger logger) {
+    public Slf4jOutput(Logger logger, boolean verbose) {
         this.logger = requireNonNull(logger, "logger");
+        this.verbose = verbose;
     }
 
     @Override
     public boolean isVerbose() {
-        return logger.isDebugEnabled();
+        return verbose;
     }
 
     @Override

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -212,20 +212,20 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
         }
 
         if (verbose) {
-            output.verbose("");
-            output.verbose("        USER PROPERTIES");
-            context.contextOverrides().getUserProperties().entrySet().stream()
+            output.normal("");
+            output.normal("        USER PROPERTIES");
+            context.repositorySystemSession().getUserProperties().entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
-                    .forEach(e -> output.verbose("                         {}={}", e.getKey(), e.getValue()));
-            output.verbose("      SYSTEM PROPERTIES");
-            context.contextOverrides().getSystemProperties().entrySet().stream()
+                    .forEach(e -> output.normal("                         {}={}", e.getKey(), e.getValue()));
+            output.normal("      SYSTEM PROPERTIES");
+            context.repositorySystemSession().getSystemProperties().entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
-                    .forEach(e -> output.verbose("                         {}={}", e.getKey(), e.getValue()));
-            output.verbose("      CONFIG PROPERTIES");
-            context.contextOverrides().getConfigProperties().entrySet().stream()
+                    .forEach(e -> output.normal("                         {}={}", e.getKey(), e.getValue()));
+            output.normal("      CONFIG PROPERTIES");
+            context.repositorySystemSession().getConfigProperties().entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
-                    .forEach(e -> output.verbose("                         {}={}", e.getKey(), e.getValue()));
-            output.verbose("");
+                    .forEach(e -> output.normal("                         {}={}", e.getKey(), e.getValue()));
+            output.normal("");
 
             output.normal("OUTPUT TEST:");
             output.verbose("Verbose: {}", "Message", new RuntimeException("runtime"));

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MojoSupport.java
@@ -57,6 +57,7 @@ public abstract class MojoSupport extends AbstractMojo implements Callable<Integ
     @CommandLine.Option(
             names = {"-v", "--verbose"},
             description = "Be verbose about things happening")
+    @Parameter(property = "verbose")
     private boolean verbose;
 
     @CommandLine.Option(
@@ -431,7 +432,7 @@ public abstract class MojoSupport extends AbstractMojo implements Callable<Integ
     // Mojo
 
     private Output createMojoOutput() {
-        return new Slf4jOutput(LoggerFactory.getLogger(getClass()));
+        return new Slf4jOutput(LoggerFactory.getLogger(getClass()), verbose);
     }
 
     @CommandLine.Option(


### PR DESCRIPTION
Dump was ok for CLI but not for embedded-maven. In any way, the dump should show "effective" properties that are in session and not in context overrides.

Also allow use of -Dverbose for Mojos