### PR TITLE
fix: better description for artifact-path

### DIFF
--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavArtifactPathMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavArtifactPathMojo.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 /**
  * Prints Maven Artifact path in local repository.
  */
-@CommandLine.Command(name = "artifact-path", description = "Prints path of Maven Artifacts in local repository")
+@CommandLine.Command(name = "artifact-path", description = "Prints expected relvative path for a given Maven coordinate in a local repository")
 @Mojo(name = "gav-artifact-path", requiresProject = false, threadSafe = true)
 public class GavArtifactPathMojo extends GavMojoSupport {
     /**


### PR DESCRIPTION
artifact-path does not actually provide the path on disk, but more the *expected relative* path of a given GAV.