### PR TITLE
Add ArtifactVersionSelector to versions call

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -396,7 +396,11 @@ public interface ToolboxCommando {
      * Finds newer versions for artifacts from source.
      */
     Result<Map<Artifact, List<Version>>> versions(
-            String context, Source<Artifact> artifacts, Predicate<Version> versionPredicate) throws Exception;
+            String context,
+            Source<Artifact> artifacts,
+            Predicate<Version> versionPredicate,
+            BiFunction<Artifact, List<Version>, String> versionSelector)
+            throws Exception;
 
     // POM editing
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -436,7 +437,14 @@ public interface ToolboxCommando {
             Map<Artifact, List<Version>> versions, BiFunction<Artifact, List<Version>, String> versionSelector) {
         return versions.entrySet().stream()
                 .filter(e -> !e.getValue().isEmpty())
-                .map(e -> e.getKey().setVersion(versionSelector.apply(e.getKey(), e.getValue())))
+                .map(e -> {
+                    String selected = versionSelector.apply(e.getKey(), e.getValue());
+                    if (Objects.equals(selected, e.getKey().getVersion())) {
+                        return null;
+                    }
+                    return e.getKey().setVersion(versionSelector.apply(e.getKey(), e.getValue()));
+                })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -429,30 +429,29 @@ public interface ToolboxCommando {
     EditSession createEditSession(Path pom) throws IOException;
 
     /**
-     * Calculates list of "latest" artifacts based on {@link #versions(String, Source, Predicate)} query result
+     * Calculates list of "latest" artifacts based on {@link #versions(String, Source, Predicate, BiFunction)} query result
      * Contains only artifacts that have updates.
      */
-    default List<Artifact> calculateUpdates(Map<Artifact, List<Version>> versions) {
+    default List<Artifact> calculateUpdates(
+            Map<Artifact, List<Version>> versions, BiFunction<Artifact, List<Version>, String> versionSelector) {
         return versions.entrySet().stream()
                 .filter(e -> !e.getValue().isEmpty())
-                .map(e -> e.getKey()
-                        .setVersion(e.getValue().get(e.getValue().size() - 1).toString()))
+                .map(e -> e.getKey().setVersion(versionSelector.apply(e.getKey(), e.getValue())))
                 .collect(Collectors.toList());
     }
 
     /**
-     * Calculates list of "latest" artifacts based on {@link #versions(String, Source, Predicate)} query result.
+     * Calculates list of "latest" artifacts based on {@link #versions(String, Source, Predicate, BiFunction)} query result.
      * Contains every artifact, even those that are already "latest".
      */
-    default List<Artifact> calculateLatest(Map<Artifact, List<Version>> versions) {
+    default List<Artifact> calculateLatest(
+            Map<Artifact, List<Version>> versions, BiFunction<Artifact, List<Version>, String> versionSelector) {
         return versions.entrySet().stream()
                 .map(e -> e.getKey()
                         .setVersion(
                                 e.getValue().isEmpty()
                                         ? e.getKey().getVersion()
-                                        : e.getValue()
-                                                .get(e.getValue().size() - 1)
-                                                .toString()))
+                                        : versionSelector.apply(e.getKey(), e.getValue())))
                 .collect(Collectors.toList());
     }
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/PomTransformerSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/PomTransformerSink.java
@@ -314,7 +314,9 @@ public final class PomTransformerSink implements Artifacts.Sink {
 
     @Override
     public void close() throws IOException {
-        new PomTransformer(pom, StandardCharsets.UTF_8, PomTransformer.SimpleElementWhitespace.AUTODETECT_PREFER_EMPTY)
-                .transform(applicableTransformations);
+        if (!applicableTransformations.isEmpty()) {
+            new PomTransformer(pom, StandardCharsets.UTF_8, PomTransformer.SimpleElementWhitespace.AUTODETECT_PREFER_EMPTY)
+                    .transform(applicableTransformations);
+        }
     }
 }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/PomTransformerSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/PomTransformerSink.java
@@ -315,7 +315,8 @@ public final class PomTransformerSink implements Artifacts.Sink {
     @Override
     public void close() throws IOException {
         if (!applicableTransformations.isEmpty()) {
-            new PomTransformer(pom, StandardCharsets.UTF_8, PomTransformer.SimpleElementWhitespace.AUTODETECT_PREFER_EMPTY)
+            new PomTransformer(
+                            pom, StandardCharsets.UTF_8, PomTransformer.SimpleElementWhitespace.AUTODETECT_PREFER_EMPTY)
                     .transform(applicableTransformations);
         }
     }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -1291,7 +1291,11 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
 
     @Override
     public Result<Map<Artifact, List<Version>>> versions(
-            String context, Source<Artifact> artifactSource, Predicate<Version> versionPredicate) throws Exception {
+            String context,
+            Source<Artifact> artifactSource,
+            Predicate<Version> versionPredicate,
+            BiFunction<Artifact, List<Version>, String> versionSelector)
+            throws Exception {
         List<Artifact> artifacts = artifactSource.get().collect(Collectors.toList());
         HashMap<Artifact, List<Version>> result = new HashMap<>();
         output.marker(Output.Verbosity.NORMAL)
@@ -1301,7 +1305,7 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
             List<Version> newer = toolboxResolver.findNewerVersions(artifact, versionPredicate);
             result.put(artifact, newer);
             if (!newer.isEmpty()) {
-                Version latest = newer.get(newer.size() - 1);
+                String latest = versionSelector.apply(artifact, newer);
                 String all = newer.stream().map(Object::toString).collect(Collectors.joining(", "));
                 output.marker(Output.Verbosity.NORMAL).scary("* {} -> {}").say(ArtifactIdUtils.toId(artifact), latest);
                 output.marker(Output.Verbosity.SUGGEST)

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -1303,18 +1303,17 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
                 .say(context, artifacts.size());
         for (Artifact artifact : artifacts) {
             List<Version> newer = toolboxResolver.findNewerVersions(artifact, versionPredicate);
+            result.put(artifact, newer);
             if (!newer.isEmpty()) {
                 String selected = versionSelector.apply(artifact, newer);
-                String all = newer.stream().map(Object::toString).collect(Collectors.joining(", "));
                 boolean changed = !Objects.equals(selected, artifact.getVersion());
                 if (changed) {
-                    result.put(artifact, newer);
                     output.marker(Output.Verbosity.NORMAL)
                             .scary("* {} -> {}")
                             .say(ArtifactIdUtils.toId(artifact), selected);
                     output.marker(Output.Verbosity.SUGGEST)
                             .detail("  Available: {}")
-                            .say(all);
+                            .say(newer.stream().map(Object::toString).collect(Collectors.joining(", ")));
                     continue;
                 }
             }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
@@ -42,12 +42,23 @@ public class GavVersionsMojo extends GavMojoSupport {
     @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
     private String artifactVersionMatcherSpec;
 
+    /**
+     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     */
+    @CommandLine.Option(
+            names = {"--artifactVersionSelectorSpec"},
+            defaultValue = "last()",
+            description = "Artifact version selector spec (default 'last()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    private String artifactVersionSelectorSpec;
+
     @Override
     protected Result<Map<Artifact, List<Version>>> doExecute() throws Exception {
         ToolboxCommando toolboxCommando = getToolboxCommando();
         return toolboxCommando.versions(
                 "GAV",
                 () -> slurp(gav).stream().map(DefaultArtifact::new),
-                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
@@ -20,6 +20,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.version.Version;
+import picocli.CommandLine;
 
 /**
  * Locks available versions of Maven Project used plugins.
@@ -39,6 +40,16 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
     private String artifactVersionMatcherSpec;
 
     /**
+     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     */
+    @CommandLine.Option(
+            names = {"--artifactVersionSelectorSpec"},
+            defaultValue = "last()",
+            description = "Artifact version selector spec (default 'last()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    private String artifactVersionSelectorSpec;
+
+    /**
      * Apply results to POM.
      */
     @Parameter(property = "applyToPom")
@@ -56,7 +67,8 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
                     () -> allManagedPluginsAsResolutionRoots(toolboxCommando, project).stream()
                             .map(ResolutionRoot::getArtifact)
                             .filter(artifactMatcher),
-                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                    toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
             if (managedPlugins.isSuccess()) {
                 allPlugins.putAll(managedPlugins.getData().orElseThrow());
             } else {
@@ -67,7 +79,8 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
                     () -> allPluginsAsResolutionRoots(toolboxCommando, project).stream()
                             .map(ResolutionRoot::getArtifact)
                             .filter(artifactMatcher),
-                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                    toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
             if (plugins.isSuccess()) {
                 allPlugins.putAll(plugins.getData().orElseThrow());
             } else {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
@@ -9,6 +9,8 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 
 import eu.maveniverse.maven.toolbox.plugin.MPPluginMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ArtifactMatcher;
+import eu.maveniverse.maven.toolbox.shared.ArtifactVersionMatcher;
+import eu.maveniverse.maven.toolbox.shared.ArtifactVersionSelector;
 import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
@@ -59,6 +61,10 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
     protected Result<Boolean> doExecute() throws Exception {
         ToolboxCommando toolboxCommando = getToolboxCommando();
         ArtifactMatcher artifactMatcher = toolboxCommando.parseArtifactMatcherSpec(artifactMatcherSpec);
+        ArtifactVersionMatcher artifactVersionMatcher =
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec);
+        ArtifactVersionSelector artifactVersionSelector =
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec);
 
         Map<Artifact, List<Version>> allPlugins = new HashMap<>();
         for (MavenProject project : mavenSession.getProjects()) {
@@ -67,8 +73,8 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
                     () -> allManagedPluginsAsResolutionRoots(toolboxCommando, project).stream()
                             .map(ResolutionRoot::getArtifact)
                             .filter(artifactMatcher),
-                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
-                    toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
+                    artifactVersionMatcher,
+                    artifactVersionSelector);
             if (managedPlugins.isSuccess()) {
                 allPlugins.putAll(managedPlugins.getData().orElseThrow());
             } else {
@@ -79,8 +85,8 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
                     () -> allPluginsAsResolutionRoots(toolboxCommando, project).stream()
                             .map(ResolutionRoot::getArtifact)
                             .filter(artifactMatcher),
-                    toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
-                    toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
+                    artifactVersionMatcher,
+                    artifactVersionSelector);
             if (plugins.isSuccess()) {
                 allPlugins.putAll(plugins.getData().orElseThrow());
             } else {
@@ -89,7 +95,7 @@ public class LockPluginVersionsMojo extends MPPluginMojoSupport {
         }
 
         if (applyToPom) {
-            List<Artifact> pluginsUpdates = toolboxCommando.calculateLatest(allPlugins);
+            List<Artifact> pluginsUpdates = toolboxCommando.calculateLatest(allPlugins, artifactVersionSelector);
             if (!pluginsUpdates.isEmpty()) {
                 try (ToolboxCommando.EditSession editSession =
                         toolboxCommando.createEditSession(mavenProject.getFile().toPath())) {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginVersionsMojo.java
@@ -18,6 +18,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.version.Version;
+import picocli.CommandLine;
 
 /**
  * Lists available versions of Maven Project plugins.
@@ -37,6 +38,16 @@ public class PluginVersionsMojo extends MPPluginMojoSupport {
     private String artifactVersionMatcherSpec;
 
     /**
+     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     */
+    @CommandLine.Option(
+            names = {"--artifactVersionSelectorSpec"},
+            defaultValue = "last()",
+            description = "Artifact version selector spec (default 'last()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    private String artifactVersionSelectorSpec;
+
+    /**
      * Apply results to POM.
      */
     @Parameter(property = "applyToPom")
@@ -51,13 +62,15 @@ public class PluginVersionsMojo extends MPPluginMojoSupport {
                 () -> allProjectManagedPluginsAsResolutionRoots(toolboxCommando).stream()
                         .map(ResolutionRoot::getArtifact)
                         .filter(artifactMatcher),
-                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
         Result<Map<Artifact, List<Version>>> plugins = toolboxCommando.versions(
                 "plugins",
                 () -> allProjectPluginsAsResolutionRoots(toolboxCommando).stream()
                         .map(ResolutionRoot::getArtifact)
                         .filter(artifactMatcher),
-                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
 
         if (applyToPom) {
             List<Artifact> managedPluginsUpdates =

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/VersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/VersionsMojo.java
@@ -17,6 +17,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.version.Version;
+import picocli.CommandLine;
 
 /**
  * Lists available versions of Maven Project dependencies.
@@ -36,6 +37,16 @@ public class VersionsMojo extends MPMojoSupport {
     private String artifactVersionMatcherSpec;
 
     /**
+     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     */
+    @CommandLine.Option(
+            names = {"--artifactVersionSelectorSpec"},
+            defaultValue = "last()",
+            description = "Artifact version selector spec (default 'last()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    private String artifactVersionSelectorSpec;
+
+    /**
      * Apply results to POM.
      */
     @Parameter(property = "applyToPom")
@@ -50,12 +61,14 @@ public class VersionsMojo extends MPMojoSupport {
                         projectManagedDependenciesAsResolutionRoots(toolboxCommando.parseDependencyMatcherSpec(depSpec))
                                 .stream()
                                 .map(ResolutionRoot::getArtifact),
-                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
         Result<Map<Artifact, List<Version>>> dependencies = toolboxCommando.versions(
                 "dependencies",
                 () -> projectDependenciesAsResolutionRoots(toolboxCommando.parseDependencyMatcherSpec(depSpec)).stream()
                         .map(ResolutionRoot::getArtifact),
-                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec));
+                toolboxCommando.parseArtifactVersionMatcherSpec(artifactVersionMatcherSpec),
+                toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec));
 
         if (applyToPom) {
             List<Artifact> managedDependenciesUpdates = toolboxCommando.calculateUpdates(


### PR DESCRIPTION
Fixes #165
Fixes #168 

The `artifactVersionMatcherSpec` narrows the set of versions to use (def is `noSnapshotsAndPreviews`), and the `artifactVersionSelectorSpec` performs the selection (def is `last`, very same as was codified and now removed, just take last element of list).