### PR TITLE
Fix aggregating mojos

### DIFF
--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MPMojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MPMojoSupport.java
@@ -105,15 +105,7 @@ public abstract class MPMojoSupport extends MojoSupport {
                                 p.getVersion(), dependency.getArtifact().getVersion()));
     }
 
-    protected ReactorLocator getReactorLocator() {
-        return new MavenReactorLocator(mavenSession);
-    }
-
-    protected ReactorLocator getReactorLocatorWithSelector(String selector) {
-        if (selector == null || selector.trim().isEmpty()) {
-            return getReactorLocator();
-        } else {
-            return new MavenReactorLocator(mavenSession, selector);
-        }
+    protected ReactorLocator getReactorLocator(String selector) {
+        return new MavenReactorLocator(mavenSession, selector);
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MPMojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MPMojoSupport.java
@@ -108,4 +108,12 @@ public abstract class MPMojoSupport extends MojoSupport {
     protected ReactorLocator getReactorLocator() {
         return new MavenReactorLocator(mavenSession);
     }
+
+    protected ReactorLocator getReactorLocatorWithSelector(String selector) {
+        if (selector == null || selector.trim().isEmpty()) {
+            return getReactorLocator();
+        } else {
+            return new MavenReactorLocator(mavenSession, selector);
+        }
+    }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MavenReactorLocator.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/MavenReactorLocator.java
@@ -36,10 +36,6 @@ public class MavenReactorLocator implements ReactorLocator {
     private final Project current;
     private final List<Project> allProjects;
 
-    public MavenReactorLocator(MavenSession session) {
-        this(session, null);
-    }
-
     public MavenReactorLocator(MavenSession session, String selector) {
         requireNonNull(session, "session");
         this.allProjects = session.getAllProjects().stream()
@@ -59,11 +55,11 @@ public class MavenReactorLocator implements ReactorLocator {
                 throw new IllegalArgumentException("Could not find 1 matching project: " + matches);
             }
             this.current = locateProject(
-                    RepositoryUtils.toArtifact(candidates.get(0).getArtifact()))
+                            RepositoryUtils.toArtifact(candidates.get(0).getArtifact()))
                     .orElseThrow();
         } else {
-            this.current = locateProject(
-                    RepositoryUtils.toArtifact(session.getCurrentProject().getArtifact()))
+            this.current = locateProject(RepositoryUtils.toArtifact(
+                            session.getCurrentProject().getArtifact()))
                     .orElseThrow();
         }
     }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
@@ -15,7 +15,7 @@ import org.eclipse.aether.collection.CollectResult;
 /**
  * Displays project inheritance of Maven Projects.
  */
-@Mojo(name = "parent-child-tree", threadSafe = true)
+@Mojo(name = "parent-child-tree", aggregator = true, threadSafe = true)
 public class ParentChildTreeMojo extends MPMojoSupport {
     @Override
     protected Result<CollectResult> doExecute() throws Exception {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
@@ -19,8 +19,9 @@ import org.eclipse.aether.collection.CollectResult;
 @Mojo(name = "parent-child-tree", aggregator = true, threadSafe = true)
 public class ParentChildTreeMojo extends MPMojoSupport {
     /**
-     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A}, {@code G:A}. The selector
-     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. If the
+     * selector is set, it must match exactly one project within reactor, otherwise it will fail. By default,
+     * selector is {@code null}, and Maven session "current project" is used.
      */
     @Parameter(property = "selector")
     private String selector;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentChildTreeMojo.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 import eu.maveniverse.maven.toolbox.plugin.MPMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.collection.CollectResult;
 
 /**
@@ -17,8 +18,15 @@ import org.eclipse.aether.collection.CollectResult;
  */
 @Mojo(name = "parent-child-tree", aggregator = true, threadSafe = true)
 public class ParentChildTreeMojo extends MPMojoSupport {
+    /**
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A}, {@code G:A}. The selector
+     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     */
+    @Parameter(property = "selector")
+    private String selector;
+
     @Override
     protected Result<CollectResult> doExecute() throws Exception {
-        return getToolboxCommando().parentChildTree(getReactorLocator());
+        return getToolboxCommando().parentChildTree(getReactorLocator(selector));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
@@ -16,7 +16,7 @@ import org.eclipse.aether.collection.CollectResult;
 /**
  * Displays project interdependencies of Maven Projects.
  */
-@Mojo(name = "project-dependency-tree", threadSafe = true)
+@Mojo(name = "project-dependency-tree", aggregator = true, threadSafe = true)
 public class ProjectDependencyTreeMojo extends MPMojoSupport {
 
     /**
@@ -25,8 +25,15 @@ public class ProjectDependencyTreeMojo extends MPMojoSupport {
     @Parameter(property = "showExternal", defaultValue = "false", required = true)
     private boolean showExternal;
 
+    /**
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. The selector
+     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     */
+    @Parameter(property = "selector")
+    private String selector;
+
     @Override
     protected Result<CollectResult> doExecute() throws Exception {
-        return getToolboxCommando().projectDependencyTree(getReactorLocator(), showExternal);
+        return getToolboxCommando().projectDependencyTree(getReactorLocatorWithSelector(selector), showExternal);
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
@@ -34,6 +34,6 @@ public class ProjectDependencyTreeMojo extends MPMojoSupport {
 
     @Override
     protected Result<CollectResult> doExecute() throws Exception {
-        return getToolboxCommando().projectDependencyTree(getReactorLocatorWithSelector(selector), showExternal);
+        return getToolboxCommando().projectDependencyTree(getReactorLocator(selector), showExternal);
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ProjectDependencyTreeMojo.java
@@ -26,8 +26,9 @@ public class ProjectDependencyTreeMojo extends MPMojoSupport {
     private boolean showExternal;
 
     /**
-     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. The selector
-     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. If the
+     * selector is set, it must match exactly one project within reactor, otherwise it will fail. By default,
+     * selector is {@code null}, and Maven session "current project" is used.
      */
     @Parameter(property = "selector")
     private String selector;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 import eu.maveniverse.maven.toolbox.plugin.MPMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.collection.CollectResult;
 
 /**
@@ -17,8 +18,15 @@ import org.eclipse.aether.collection.CollectResult;
  */
 @Mojo(name = "subproject-tree", aggregator = true, threadSafe = true)
 public class SubprojectTreeMojo extends MPMojoSupport {
+    /**
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. The selector
+     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     */
+    @Parameter(property = "selector")
+    private String selector;
+
     @Override
     protected Result<CollectResult> doExecute() throws Exception {
-        return getToolboxCommando().subprojectTree(getReactorLocator());
+        return getToolboxCommando().subprojectTree(getReactorLocator(selector));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
@@ -19,8 +19,9 @@ import org.eclipse.aether.collection.CollectResult;
 @Mojo(name = "subproject-tree", aggregator = true, threadSafe = true)
 public class SubprojectTreeMojo extends MPMojoSupport {
     /**
-     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. The selector
-     * string must match ONE project within reactor, otherwise (matches 0 or more than 1) it will fail.
+     * Set the project selector, like {@code -rf} Maven command uses it, can be {@code :A} or {@code G:A}. If the
+     * selector is set, it must match exactly one project within reactor, otherwise it will fail. By default,
+     * selector is {@code null}, and Maven session "current project" is used.
      */
     @Parameter(property = "selector")
     private String selector;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/SubprojectTreeMojo.java
@@ -15,7 +15,7 @@ import org.eclipse.aether.collection.CollectResult;
 /**
  * Displays subproject collection of Maven Projects.
  */
-@Mojo(name = "subproject-tree", threadSafe = true)
+@Mojo(name = "subproject-tree", aggregator = true, threadSafe = true)
 public class SubprojectTreeMojo extends MPMojoSupport {
     @Override
     protected Result<CollectResult> doExecute() throws Exception {


### PR DESCRIPTION
Changes:
* parent-child-tree made aggregator
* subproject-tree made agregator
* project-dependency-tree made aggregator

Former two should be run from same spot from where you'd invoke 'full build', while latter allows targeting project using `-Dselector=` where value may be `:A`, `:A:V`, `G:A` or `G:A:V`. Selector must match exactly 1 project, otherwise (0 or 2+ matches) it will fail.