### PR TITLE
flatten-bom

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -337,6 +337,11 @@ public interface ToolboxCommando {
      */
     Result<Model> effectiveModel(ReactorLocator reactorLocator) throws Exception;
 
+    /**
+     * Returns the effective model flattened BOM. Works only for "loaded" BOMs naturally, so it has to be installed or deployed..
+     */
+    Result<Model> flattenBOM(Artifact artifact, ResolutionRoot resolutionRoot) throws Exception;
+
     // Search API related commands: they target one single RemoteRepository
 
     /**

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -1008,6 +1008,7 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
             Model resultModel = new MavenXpp3Reader()
                     .read(new StringReader(PomSuppliers.empty400(
                             artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion())));
+            resultModel.setPackaging("pom");
             resultModel.setDependencyManagement(new DependencyManagement());
 
             Model bomModel = result.getData().orElseThrow();

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavFlattenBomMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavFlattenBomMojo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.plugin.gav;
+
+import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
+import eu.maveniverse.maven.toolbox.shared.Result;
+import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import picocli.CommandLine;
+
+/**
+ * Flattens a BOM.
+ */
+@CommandLine.Command(name = "flatten-bom", description = "Flattens a BOM")
+@Mojo(name = "gav-flatten-bom", requiresProject = false, threadSafe = true)
+public class GavFlattenBomMojo extends GavMojoSupport {
+    /**
+     * The GAV to emit flattened BOM with.
+     */
+    @CommandLine.Parameters(
+            index = "0",
+            defaultValue = "org.acme:acme:1.0",
+            description = "The GAV to emit flattened BOM with")
+    @Parameter(property = "gav", defaultValue = "org.acme:acme:1.0")
+    private String gav;
+
+    /**
+     * The GAV of BOM to flatten.
+     */
+    @CommandLine.Parameters(index = "0", description = "The GAV of BOM to flatten")
+    @Parameter(property = "bom", required = true)
+    private String bom;
+
+    @Override
+    protected Result<Model> doExecute() throws Exception {
+        ToolboxCommando toolboxCommando = getToolboxCommando();
+        return toolboxCommando.flattenBOM(new DefaultArtifact(gav), toolboxCommando.loadGav(bom));
+    }
+}


### PR DESCRIPTION
A new mojo that helps you to maintain (and synchronize) with published (but bloated) BOMs.

```
mvn toolbox:flatten-bom -Dbom=g:a:v
```

And outputs flat BOM, that is in fact "effective BOM" with all conflicts (and recursion, most importantly) removed. The BOM being flattened must be resolvable (installed or deployed).

Optionally, you can specify `-Dgav=g:a:v` and output will be a BOM POM with provided coordinates.

Example invocation:
https://gist.github.com/cstamas/9fa43d43602e4fd9f28787e8f3cadd73