### PR TITLE
Fix for module infos and improve logging

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
@@ -118,11 +118,7 @@ public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, Dep
         } catch (SecurityException | IllegalArgumentException e) {
             output.warn("Ignored Exception:", e);
         } catch (FindException e) {
-            Throwable cause = e.getCause();
-            while (cause.getCause() != null) {
-                cause = cause.getCause();
-            }
-            output.warn("Can't extract module name from {}:", artifactPath.getFileName(), cause);
+            output.warn("Can't extract module name from {}:", artifactPath.getFileName(), e);
         }
         return moduleDescriptor;
     }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
@@ -33,12 +33,26 @@ import org.eclipse.aether.graph.DependencyVisitor;
  */
 public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, DependencyVisitor {
     public interface ModuleDescriptor {
+        /**
+         * Returns {@code true} if the module descriptor was found (or derived somehow). Otherwise, it is not available,
+         * and all the others methods return values are undefined.
+         */
         boolean available();
 
+        /**
+         * If {@link #available()} is {@code true}, the module name.
+         */
         String name();
 
+        /**
+         * If {@link #available()} is {@code true}, return {@code true} if module was automatic module.
+         */
         boolean automatic();
 
+        /**
+         * If {@link #available()} is {@code true}, and {@link #automatic()} is {@code true} as well, returns the
+         * source of automatic module name ("MANIFEST" or "FILENAME").
+         */
         String moduleNameSource();
     }
 
@@ -66,9 +80,9 @@ public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, Dep
             moduleInfo = "-- module " + moduleDescriptor.name();
             if (moduleDescriptor.automatic()) {
                 if ("MANIFEST".equals(moduleDescriptor.moduleNameSource())) {
-                    moduleInfo += " [auto]";
+                    moduleInfo += " [automatic; JAR manifest]";
                 } else {
-                    moduleInfo += " (auto)";
+                    moduleInfo += " (automatic: JAR filename)";
                 }
             }
         }
@@ -159,7 +173,7 @@ public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, Dep
 
         @Override
         public String name() {
-            return "n/a";
+            return "";
         }
 
         @Override

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ModuleDescriptorExtractingSink.java
@@ -188,13 +188,11 @@ public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, Dep
     };
 
     private static class ModuleDescriptorImpl implements ModuleDescriptor {
-        private final boolean available;
         private final String name;
         private final boolean automatic;
         private final String moduleNameSource;
 
         private ModuleDescriptorImpl(String name, boolean automatic, String moduleNameSource) {
-            this.available = true;
             this.name = name;
             this.automatic = automatic;
             this.moduleNameSource = moduleNameSource;
@@ -202,7 +200,7 @@ public final class ModuleDescriptorExtractingSink implements Artifacts.Sink, Dep
 
         @Override
         public boolean available() {
-            return available;
+            return true;
         }
 
         @Override

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/output/LoggerOutput.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/output/LoggerOutput.java
@@ -23,9 +23,10 @@ public final class LoggerOutput extends OutputSupport {
 
     @Override
     public void warn(String message, Object... params) {
-        if (!isShowErrors() && params.length > 0 || params[params.length - 1] instanceof Throwable) {
-            Object[] paramsWithoutThrowable = Arrays.copyOf(params, params.length - 1);
-            output.warn(message + " " + ((Throwable) params[params.length - 1]).getMessage(), paramsWithoutThrowable);
+        if (!isShowErrors() && params.length > 0 && params[params.length - 1] instanceof Throwable) {
+            output.warn(
+                    message + " " + ((Throwable) params[params.length - 1]).getMessage(),
+                    Arrays.copyOf(params, params.length - 1));
         } else {
             output.warn(message, params);
         }
@@ -33,9 +34,10 @@ public final class LoggerOutput extends OutputSupport {
 
     @Override
     public void error(String message, Object... params) {
-        if (!isShowErrors() && params.length > 0 || params[params.length - 1] instanceof Throwable) {
-            Object[] paramsWithoutThrowable = Arrays.copyOf(params, params.length - 1);
-            output.error(message + " " + ((Throwable) params[params.length - 1]).getMessage(), paramsWithoutThrowable);
+        if (!isShowErrors() && params.length > 0 && params[params.length - 1] instanceof Throwable) {
+            output.error(
+                    message + " " + ((Throwable) params[params.length - 1]).getMessage(),
+                    Arrays.copyOf(params, params.length - 1));
         } else {
             output.error(message, params);
         }

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/output/LoggerOutput.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/output/LoggerOutput.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.toolbox.shared.output;
 
+import java.util.Arrays;
 import org.slf4j.Logger;
 
 /**
@@ -15,19 +16,29 @@ import org.slf4j.Logger;
 public final class LoggerOutput extends OutputSupport {
     private final Logger output;
 
-    public LoggerOutput(Logger output, Verbosity verbosity) {
-        super(verbosity, true);
+    public LoggerOutput(Logger output, boolean errors, Verbosity verbosity) {
+        super(verbosity, errors);
         this.output = output;
     }
 
     @Override
     public void warn(String message, Object... params) {
-        output.warn(message, params);
+        if (!isShowErrors() && params.length > 0 || params[params.length - 1] instanceof Throwable) {
+            Object[] paramsWithoutThrowable = Arrays.copyOf(params, params.length - 1);
+            output.warn(message + " " + ((Throwable) params[params.length - 1]).getMessage(), paramsWithoutThrowable);
+        } else {
+            output.warn(message, params);
+        }
     }
 
     @Override
     public void error(String message, Object... params) {
-        output.error(message, params);
+        if (!isShowErrors() && params.length > 0 || params[params.length - 1] instanceof Throwable) {
+            Object[] paramsWithoutThrowable = Arrays.copyOf(params, params.length - 1);
+            output.error(message + " " + ((Throwable) params[params.length - 1]).getMessage(), paramsWithoutThrowable);
+        } else {
+            output.error(message, params);
+        }
     }
 
     @Override

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/OutputFactory.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/OutputFactory.java
@@ -36,7 +36,7 @@ public final class OutputFactory {
      */
     public static Output createMojoOutput(boolean batchMode, boolean errors, Output.Verbosity verbosity) {
         requireNonNull(verbosity, "verbosity");
-        Output output = new LoggerOutput(LoggerFactory.getLogger(OutputFactory.class), verbosity);
+        Output output = new LoggerOutput(LoggerFactory.getLogger(OutputFactory.class), errors, verbosity);
         if (!batchMode && System.console() != null) {
             if (!Ansi.isEnabled()) {
                 Ansi.setEnabled(true);


### PR DESCRIPTION
Changes:
* given Toolbox is Java 11, no more reflection needed
* be smarter about cases when JDK throw (https://bugs.openjdk.org/browse/JDK-8301864)
* when running in Mojo, obey `-e` (by def no stack trace, only if user asks with `-e`)

Fixes #182 
Fixes #183 
Fixes #185 