### PR TITLE
The lock-plugin-versions fix

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/jdom/JDomPomEditor.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/jdom/JDomPomEditor.java
@@ -282,6 +282,20 @@ public final class JDomPomEditor {
         }
     }
 
+    public static void deletePluginVersion(Element project, Artifact a) {
+        if (project != null) {
+            Element plugins = project.getChild("plugins", project.getNamespace());
+            if (plugins != null) {
+                for (Element plugin : plugins.getChildren("plugin", plugins.getNamespace())) {
+                    if (equalsGA(a, plugin)) {
+                        Element version = plugin.getChild("version", plugin.getNamespace());
+                        JDomUtils.removeChildAndItsCommentFromContent(plugin, version);
+                    }
+                }
+            }
+        }
+    }
+
     public static void updateManagedDependency(Element project, Artifact a, boolean upsert) {
         if (project != null) {
             Element dependencyManagement = project.getChild("dependencyManagement", project.getNamespace());

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/jdom/JDomPomTransformer.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/jdom/JDomPomTransformer.java
@@ -67,6 +67,12 @@ public final class JDomPomTransformer {
         };
     }
 
+    public static Function<Artifact, Consumer<TransformationContext>> deletePluginVersion() {
+        return a -> context -> {
+            JDomPomEditor.deletePluginVersion(context.getDocument().getRootElement(), a);
+        };
+    }
+
     public static Function<Artifact, Consumer<TransformationContext>> updateManagedDependency(boolean upsert) {
         return a -> context ->
                 JDomPomEditor.updateManagedDependency(context.getDocument().getRootElement(), a, upsert);

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LockPluginVersionsMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.version.Version;
 import picocli.CommandLine;
 


### PR DESCRIPTION
That should drop versions in plugin/plugins for all added managed plugin.

Fixes #195 