### PR TITLE
Toolbox improvements

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ProjectLocator.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ProjectLocator.java
@@ -7,8 +7,10 @@
  */
 package eu.maveniverse.maven.toolbox.shared;
 
+import eu.maveniverse.maven.toolbox.shared.internal.Dependencies;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
 
@@ -19,7 +21,7 @@ public interface ProjectLocator {
     /**
      * Represents single project.
      */
-    interface Project {
+    interface Project extends Dependencies.Source {
         Artifact artifact();
 
         Optional<Artifact> getParent();
@@ -27,6 +29,11 @@ public interface ProjectLocator {
         List<Dependency> dependencies();
 
         ProjectLocator origin();
+
+        @Override
+        default Stream<Dependency> get() {
+            return dependencies().stream();
+        }
     }
     /**
      * Locates project by given artifact. If not present, it means artifact is "external" relative to these projects.

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxCommando.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.toolbox.shared;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
 import eu.maveniverse.maven.toolbox.shared.internal.ToolboxCommandoImpl;
 import eu.maveniverse.maven.toolbox.shared.internal.domtrip.SmartPomEditor;
 import eu.maveniverse.maven.toolbox.shared.output.Output;
@@ -50,7 +51,7 @@ import org.eclipse.aether.version.Version;
  * mark "bad input", or configuration related errors. The checked exception instances on the other hand come from
  * corresponding subsystem like resolver is. Finally, {@link IOException} is thrown on fatal IO problems.
  */
-public interface ToolboxCommando {
+public interface ToolboxCommando extends Closeable {
     /**
      * Gets or creates context. This method should be used to get instance that may be shared
      * across context (session).
@@ -60,6 +61,11 @@ public interface ToolboxCommando {
         requireNonNull(context, "context");
         return new ToolboxCommandoImpl(output, context);
     }
+
+    ToolboxCommando withContextOverrides(ContextOverrides overrides);
+
+    @Override
+    void close();
 
     default String getVersion() {
         return ToolboxCommandoVersion.getVersion();
@@ -165,9 +171,10 @@ public interface ToolboxCommando {
     // Commands
 
     /**
-     * Calculates the classpath (returned string is OS FS specific) of given scope and root.
+     * Calculates the classpath (returned string is OS FS specific) of given scope and roots.
      */
-    Result<String> classpath(ResolutionScope resolutionScope, ResolutionRoot resolutionRoot) throws Exception;
+    Result<String> classpath(ResolutionScope resolutionScope, Collection<ResolutionRoot> resolutionRoots)
+            throws Exception;
 
     /**
      * Returns the list of artifacts copied from source to sink.
@@ -340,7 +347,7 @@ public interface ToolboxCommando {
     Result<Model> effectiveModel(ReactorLocator reactorLocator) throws Exception;
 
     /**
-     * Returns the effective model flattened BOM. Works only for "loaded" BOMs naturally, so it has to be installed or deployed..
+     * Returns the effective model flattened BOM. Works only for "loaded" BOMs naturally, so it has to be installed or deployed.
      */
     Result<Model> flattenBOM(Artifact artifact, ResolutionRoot resolutionRoot) throws Exception;
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxResolver.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ToolboxResolver.java
@@ -92,6 +92,9 @@ public interface ToolboxResolver {
 
     CollectResult projectDependencyTree(ReactorLocator reactorLocator, boolean showExternal);
 
+    DependencyResult resolve(ResolutionScope resolutionScope, ResolutionRoot resolutionRoot)
+            throws DependencyResolutionException;
+
     DependencyResult resolve(
             ResolutionScope resolutionScope,
             Artifact root,

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/input/StringSlurper.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/input/StringSlurper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.shared.input;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Input handling helper.
+ */
+public final class StringSlurper {
+    private StringSlurper() {}
+
+    /**
+     * Splits comma separated string into elements.
+     */
+    public static Collection<String> csv(String csv) {
+        if (csv == null || csv.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(csv.split(","));
+    }
+
+    /**
+     * Slurps, either comma separated string, or if value is existing file, will read
+     * up the file with values on separate lines.
+     */
+    public static Collection<String> slurp(String csv) throws IOException {
+        if (csv == null || csv.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        try {
+            Path target = Path.of(csv).toAbsolutePath();
+            if (Files.isRegularFile(target) && Files.size(target) < 5_000_000) {
+                return Files.readAllLines(target);
+            }
+        } catch (InvalidPathException e) {
+            // ignore
+        }
+        return csv(csv);
+    }
+}

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSources.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSources.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.toolbox.shared.ArtifactMapper;
 import eu.maveniverse.maven.toolbox.shared.ArtifactMatcher;
+import eu.maveniverse.maven.toolbox.shared.input.StringSlurper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -60,6 +61,11 @@ public final class ArtifactSources {
                 case "gav": {
                     String gav = stringParam(node.getValue());
                     params.add(gavArtifactSource(gav));
+                    break;
+                }
+                case "gavs": {
+                    String gav = stringParam(node.getValue());
+                    params.add(gavsArtifactSource(gav));
                     break;
                 }
                 case "directory": {
@@ -211,6 +217,24 @@ public final class ArtifactSources {
         @Override
         public Stream<Artifact> get() throws IOException {
             return Stream.of(new DefaultArtifact(gav));
+        }
+    }
+
+    public static Artifacts.Source gavsArtifactSource(String gavs) {
+        requireNonNull(gavs, "gavs");
+        return new GavsArtifactSource(gavs);
+    }
+
+    public static class GavsArtifactSource implements Artifacts.Source {
+        private final String gavs;
+
+        private GavsArtifactSource(String gavs) {
+            this.gavs = gavs;
+        }
+
+        @Override
+        public Stream<Artifact> get() throws IOException {
+            return StringSlurper.slurp(gavs).stream().map(DefaultArtifact::new);
         }
     }
 

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/GavMojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/GavMojoSupport.java
@@ -9,46 +9,14 @@ package eu.maveniverse.maven.toolbox.plugin;
 
 import eu.maveniverse.maven.toolbox.shared.ProjectArtifacts;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Support class for "project unaware" Mojos (not needing project).
  */
 public abstract class GavMojoSupport extends MojoSupport {
     /**
-     * Splits comma separated string into elements.
+     * Makes {@link ProjectArtifacts} out of supplied elements.
      */
-    protected Collection<String> csv(String csv) {
-        if (csv == null || csv.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-        return Arrays.asList(csv.split(","));
-    }
-    /**
-     * Slurps, either comma separated string, or if value is existing file, will read
-     * up the file with values on separate lines.
-     */
-    protected Collection<String> slurp(String csv) throws IOException {
-        if (csv == null || csv.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-        try {
-            Path target = Path.of(csv).toAbsolutePath();
-            if (Files.isRegularFile(target) && Files.size(target) < 5_000_000) {
-                return Files.readAllLines(target);
-            }
-        } catch (InvalidPathException e) {
-            // ignore
-        }
-        return csv(csv);
-    }
-
     protected ProjectArtifacts projectArtifacts(String gav, File jar, File pom, File sources, File javadoc) {
         ProjectArtifacts.Builder builder = new ProjectArtifacts.Builder(gav);
         builder.addMain(jar.toPath());

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavClasspathMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavClasspathMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;
@@ -23,7 +25,8 @@ import picocli.CommandLine;
 public class GavClasspathMojo extends GavMojoSupport {
     /**
      * The artifact coordinates in the format {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}
-     * to display tree for.
+     * to display tree for. May contain multiple comma separated coordinates, or point to a file that contains
+     * coordinates, separated by newline.
      */
     @CommandLine.Parameters(index = "0", description = "The GAV to print classpath for")
     @Parameter(property = "gav", required = true)
@@ -52,6 +55,7 @@ public class GavClasspathMojo extends GavMojoSupport {
     @Override
     protected Result<String> doExecute() throws Exception {
         ToolboxCommando toolboxCommando = getToolboxCommando();
-        return toolboxCommando.classpath(ResolutionScope.parse(scope), toolboxCommando.loadGav(gav, slurp(boms)));
+        return toolboxCommando.classpath(
+                ResolutionScope.parse(scope), toolboxCommando.loadGavs(slurp(gav), slurp(boms)));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyGavMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyGavMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyTransitiveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyTransitiveMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDirtyTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDirtyTreeMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDmListMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDmListMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDmTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavDmTreeMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavIdentifyMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavIdentifyMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.csv;
+
 import eu.maveniverse.maven.toolbox.plugin.GavSearchMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavSearchMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavListAvailablePluginsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavListAvailablePluginsMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.csv;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavListRepositoriesMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavListRepositoriesMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavResolveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavResolveMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavResolveTransitiveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavResolveTransitiveMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavTreeMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavTreeMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.toolbox.plugin.gav;
 
+import static eu.maveniverse.maven.toolbox.shared.input.StringSlurper.slurp;
+
 import eu.maveniverse.maven.toolbox.plugin.GavMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ClasspathMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ClasspathMojo.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.toolbox.plugin.mp;
 import eu.maveniverse.maven.toolbox.plugin.MPMojoSupport;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;
+import java.util.Collections;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -26,6 +27,7 @@ public class ClasspathMojo extends MPMojoSupport {
 
     @Override
     protected Result<String> doExecute() throws Exception {
-        return getToolboxCommando().classpath(ResolutionScope.parse(scope), projectAsResolutionRoot());
+        return getToolboxCommando()
+                .classpath(ResolutionScope.parse(scope), Collections.singletonList(projectAsResolutionRoot()));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginClasspathMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginClasspathMojo.java
@@ -12,6 +12,7 @@ import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import java.util.Collections;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -31,7 +32,7 @@ public class PluginClasspathMojo extends MPPluginMojoSupport {
         ToolboxCommando toolboxCommando = getToolboxCommando();
         ResolutionRoot root = pluginAsResolutionRoot(toolboxCommando, true);
         if (root != null) {
-            return toolboxCommando.classpath(ResolutionScope.parse(scope), root);
+            return toolboxCommando.classpath(ResolutionScope.parse(scope), Collections.singletonList(root));
         } else {
             return Result.failure("No such plugin");
         }


### PR DESCRIPTION
Changes:
* project is now `Dependencies.Source`
* ToolboxCommando is now customizable, first improvement is `-DextraRepositories` (mojo) or `--extra-repositories` (CLI) that accepts comma separated list of repo defs (`id::url`).
* new `Artifacts.Source` called `gavs`: it accepts one (String) parameter, that can be a comma separated list of `g:a:v` or even a file containing them one per each line.
* resolution overhaul and simplification

Result: one now can do this:
```
MY_CLASSPATH=$(mvn toolbox:gav-classpath -Dgav=dependencies.txt -DextraRepositories=jitpack::https://jitpack.io -q -DforceStdout)
```

or

```
MY_CLASSPATH=$(jbang toolbox@maveniverse classpath --extra-repositories=jitpack::https://jitpack.io dependencies.txt)
```