### PR TITLE
Bugfix: Toolbox uses FULL verbosity

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxResolverImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxResolverImpl.java
@@ -527,7 +527,7 @@ public class ToolboxResolverImpl implements ToolboxResolver {
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(this.session);
         session.setConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, true);
         if (verbose) {
-            session.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, ConflictResolver.Verbosity.FULL);
+            session.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, ConflictResolver.Verbosity.STANDARD);
         }
         boolean dirtyTree = dirtyMaxLevel > 0;
         if (dirtyTree) {


### PR DESCRIPTION
But in fact it does not prepare session for it. Fallback to "standard" verbosity for now.