### PR TITLE
Improvement: print out scope for tree-find

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ToolboxCommandoImpl.java
@@ -966,7 +966,10 @@ public class ToolboxCommandoImpl implements ToolboxCommando {
                 result.add(path.stream().map(DependencyNode::getArtifact).collect(Collectors.toList()));
                 String indent = "";
                 for (DependencyNode node : path) {
-                    output.tell("{}-> {}", indent, node.getArtifact());
+                    output.tell(
+                            "{}-> {}",
+                            indent,
+                            node.getDependency() != null ? node.getDependency() : node.getArtifact());
                     indent += "  ";
                 }
             }


### PR DESCRIPTION
If there is dependency, use that to print, and show scope as well. Otherwise fall back to always present artifact.