### PR TITLE
Mojo Concurrency Fix

### DIFF
--- a/mvnsh/src/main/java/eu/maveniverse/maven/toolbox/plugin/mvnsh/ToolboxShellCommandRegistryFactory.java
+++ b/mvnsh/src/main/java/eu/maveniverse/maven/toolbox/plugin/mvnsh/ToolboxShellCommandRegistryFactory.java
@@ -10,7 +10,11 @@ package eu.maveniverse.maven.toolbox.plugin.mvnsh;
 import eu.maveniverse.maven.mima.context.Runtimes;
 import eu.maveniverse.maven.mima.runtime.standalonestatic.StandaloneStaticRuntime;
 import eu.maveniverse.maven.toolbox.plugin.CLI;
+import eu.maveniverse.maven.toolbox.plugin.ContextMapAware;
 import eu.maveniverse.maven.toolbox.plugin.CwdAware;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.maven.cling.invoker.LookupContext;
@@ -25,6 +29,9 @@ import picocli.shell.jline3.PicocliCommands;
 @Named("toolbox")
 @Singleton
 public class ToolboxShellCommandRegistryFactory implements ShellCommandRegistryFactory {
+    // shared context for all mvnsh commands
+    private final Map<Object, Object> contextMap = Collections.synchronizedMap(new HashMap<>());
+
     @Override
     public CommandRegistry createShellCommandRegistry(LookupContext lookupContext) {
         Runtimes.INSTANCE.registerRuntime(new StandaloneStaticRuntime());
@@ -35,6 +42,9 @@ public class ToolboxShellCommandRegistryFactory implements ShellCommandRegistryF
                 K result = super.create(clazz);
                 if (result instanceof CwdAware cwdAware) {
                     cwdAware.setCwd(lookupContext.cwd.get());
+                }
+                if (result instanceof ContextMapAware contextMapAware) {
+                    contextMapAware.setContextMap(contextMap);
                 }
                 return result;
             }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/ContextMapAware.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/ContextMapAware.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.plugin;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface ContextMapAware {
+    /**
+     * Sets context. The map must be non-null.
+     */
+    void setContextMap(Map<Object, Object> context);
+
+    /**
+     * Returns context, if set.
+     */
+    Optional<Map<Object, Object>> getContextMap();
+}

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/CwdAware.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/CwdAware.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.toolbox.plugin;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 public interface CwdAware {
     /**
@@ -18,15 +19,15 @@ public interface CwdAware {
     void setCwd(Path cwd);
 
     /**
-     * Returns CWD; a non-null path that points to existing directory.
+     * Returns CWD, if set; a non-null path that points to existing directory.
      */
-    Path getCwd();
+    Optional<Path> getCwd();
 
     /**
-     * Resolves against CWD.
+     * Resolves against CWD, if set.
      */
     default Path resolve(Path path) {
         requireNonNull(path, "path");
-        return getCwd().resolve(path).normalize().toAbsolutePath();
+        return getCwd().orElseThrow().resolve(path).normalize().toAbsolutePath();
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/hello/HelloMojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/hello/HelloMojoSupport.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
  */
 public abstract class HelloMojoSupport extends GavMojoSupport {
     protected Path getRootPom() {
-        return getCwd().resolve("pom.xml");
+        return resolve(Path.of("pom.xml"));
     }
 
     /**


### PR DESCRIPTION
The toolbox classes are a bit tricky: they are Maven Mojos, but also also CLI/Picocli commands as well. By default, they are "one-shot" and should run as such.

But, in some special cases (REPL, or mvnsh), their context should be carried on, but not always.

The CONTEXT was `static` to carry on contextual information, but this was wrong, as it is needed only in afore mentioned cases, but not when running as Mojo (where it in fact introduces concurrency issues).

Fix is that two places (REPL and mvnsh) explicitly carries over context, while in case of Mojo they are using own context.