### PR TITLE
Cumulative fixes

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactDifferentiator.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactDifferentiator.java
@@ -78,8 +78,12 @@ public interface ArtifactDifferentiator extends Function<Artifact, String> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactKeyFactoryBuilder builder = new ArtifactKeyFactoryBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid artifact differentiator spec: " + spec, e);
+        }
     }
 
     class ArtifactKeyFactoryBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactKeyFactory.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactKeyFactory.java
@@ -59,8 +59,12 @@ public interface ArtifactKeyFactory extends Function<Artifact, String> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactKeyFactoryBuilder builder = new ArtifactKeyFactoryBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact key factory spec:" + spec, e);
+        }
     }
 
     class ArtifactKeyFactoryBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactMapper.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactMapper.java
@@ -140,8 +140,12 @@ public interface ArtifactMapper extends Function<Artifact, Artifact> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactMapperBuilder builder = new ArtifactMapperBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact mapper spec:" + spec, e);
+        }
     }
 
     class ArtifactMapperBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactMatcher.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactMatcher.java
@@ -117,8 +117,12 @@ public interface ArtifactMatcher extends Predicate<Artifact> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactMatcherBuilder builder = new ArtifactMatcherBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact matcher spec: " + spec, e);
+        }
     }
 
     class ArtifactMatcherBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactNameMapper.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactNameMapper.java
@@ -304,8 +304,12 @@ public interface ArtifactNameMapper extends Function<Artifact, String> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactNameMapperBuilder builder = new ArtifactNameMapperBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact name mapper spec: " + spec, e);
+        }
     }
 
     class ArtifactNameMapperBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionMatcher.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionMatcher.java
@@ -181,8 +181,12 @@ public interface ArtifactVersionMatcher extends Predicate<Version> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         ArtifactVersionMatcherBuilder builder = new ArtifactVersionMatcherBuilder(versionScheme, properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid version matcher spec: " + spec, e);
+        }
     }
 
     class ArtifactVersionMatcherBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelector.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelector.java
@@ -157,8 +157,12 @@ public interface ArtifactVersionSelector extends BiFunction<Artifact, List<Versi
         requireNonNull(spec, "spec");
         ArtifactVersionSelector.ArtifactVersionSelectorBuilder builder =
                 new ArtifactVersionSelector.ArtifactVersionSelectorBuilder(versionScheme, properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact version selector spec: " + spec, e);
+        }
     }
 
     class ArtifactVersionSelectorBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/DependencyMatcher.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/DependencyMatcher.java
@@ -109,8 +109,12 @@ public interface DependencyMatcher extends Predicate<Dependency> {
         requireNonNull(properties, "properties");
         requireNonNull(spec, "spec");
         DependencyMatcherBuilder builder = new DependencyMatcherBuilder(properties);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid dependency matcher spec: " + spec, e);
+        }
     }
 
     class DependencyMatcherBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSources.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSources.java
@@ -41,8 +41,12 @@ public final class ArtifactSources {
         requireNonNull(tc, "tc");
         requireNonNull(spec, "spec");
         ArtifactSourceBuilder builder = new ArtifactSourceBuilder(properties, tc);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid artifact source spec:" + spec, e);
+        }
     }
 
     static class ArtifactSourceBuilder extends SpecParser.Builder {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/DependencySinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/DependencySinks.java
@@ -36,8 +36,12 @@ public final class DependencySinks {
         requireNonNull(tc, "tc");
         requireNonNull(spec, "spec");
         DependencySinkBuilder builder = new DependencySinkBuilder(properties, tc, dryRun);
-        SpecParser.parse(spec).accept(builder);
-        return builder.build();
+        try {
+            SpecParser.parse(spec).accept(builder);
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid dependency sink spec: " + spec, e);
+        }
     }
 
     static class DependencySinkBuilder extends SpecParser.Builder {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyGavMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyGavMojo.java
@@ -22,7 +22,10 @@ import picocli.CommandLine;
 
 /**
  * Resolves a given GAV and copies resulting artifact to target.
+ *
+ * @deprecated Use {@code copy resolve(gav(GAV)) sink} instead.
  */
+@Deprecated
 @CommandLine.Command(name = "copy-gav", description = "Resolves Maven Artifact and copies it to target")
 @Mojo(name = "gav-copy-gav", requiresProject = false, threadSafe = true)
 public final class GavCopyGavMojo extends GavMojoSupport {

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyTransitiveMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavCopyTransitiveMojo.java
@@ -21,7 +21,10 @@ import picocli.CommandLine;
 
 /**
  * Resolves Maven Artifact transitively and copies all of them to target.
+ *
+ * @deprecated Use {@code copy resolveTransitive(gav(GAV), scope)) sink} instead.
  */
+@Deprecated
 @CommandLine.Command(
         name = "copy-transitive",
         description = "Resolves Maven Artifact transitively and copies all of them to target")


### PR DESCRIPTION
Changes:
* improve parser error messages ("invalid spec string" -> "invalid XXX spec string", tell WHICH spec)
* introduce `stat()` zero param command with meaning `stat(true)`
* deprecate two redundant command

Fixes #250