### PR TITLE
Contextual filtering

### DIFF
--- a/mcp/src/main/java/eu/maveniverse/maven/toolbox/mcp/ToolboxTools.java
+++ b/mcp/src/main/java/eu/maveniverse/maven/toolbox/mcp/ToolboxTools.java
@@ -57,15 +57,30 @@ public class ToolboxTools {
         return outputStream.toString(StandardCharsets.UTF_8);
     }
 
-    @Tool(description = "Get the Maven Artifact newer versions than the one specified.")
-    String artifactNewerVersions(@ToolArg(description = "The artifact as groupId:artifactId:version") String gav) {
+    @Tool(description = "Get the Maven Artifact any newer versions than the one specified.")
+    String artifactNewerAnyVersions(@ToolArg(description = "The artifact as groupId:artifactId:version") String gav) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (ToolboxCommandoImpl toolboxCommando = createToolboxCommando(outputStream)) {
             toolboxCommando.versions(
                     "artifact",
                     ArtifactSources.gavArtifactSource(gav),
-                    ArtifactVersionMatcher.noPreviews(),
-                    ArtifactVersionSelector.last());
+                    ArtifactVersionMatcher.any(),
+                    ArtifactVersionSelector.contextualSnapshotsAndPreviews(ArtifactVersionSelector.last()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return outputStream.toString(StandardCharsets.UTF_8);
+    }
+
+    @Tool(description = "Get the Maven Artifact same major newer versions than the one specified.")
+    String artifactNewerMajorVersions(@ToolArg(description = "The artifact as groupId:artifactId:version") String gav) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ToolboxCommandoImpl toolboxCommando = createToolboxCommando(outputStream)) {
+            toolboxCommando.versions(
+                    "artifact",
+                    ArtifactSources.gavArtifactSource(gav),
+                    ArtifactVersionMatcher.any(),
+                    ArtifactVersionSelector.contextualSnapshotsAndPreviews(ArtifactVersionSelector.major()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -174,8 +189,8 @@ public class ToolboxTools {
                     ResolutionRoot.ofLoaded(new DefaultArtifact(gav)).build(),
                     true,
                     false,
-                    ArtifactVersionMatcher.noPreviews(),
-                    ArtifactVersionSelector.last(),
+                    ArtifactVersionMatcher.any(),
+                    ArtifactVersionSelector.contextualSnapshotsAndPreviews(ArtifactVersionSelector.last()),
                     null);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelectorTest.java
+++ b/shared/src/test/java/eu/maveniverse/maven/toolbox/shared/ArtifactVersionSelectorTest.java
@@ -39,9 +39,13 @@ public class ArtifactVersionSelectorTest {
             version("3.1.0"),
             version("3.1.1M1"),
             version("3.100.0"),
+            version("3.101.0RC"),
+            version("3.200.0-SNAPSHOT"),
             version("4.0.0RC"),
             version("4.0.0"),
-            version("400.0.0"));
+            version("400.0.0"),
+            version("401.0.0RC"),
+            version("410.0.0-SNAPSHOT"));
 
     @Test
     void identity() {
@@ -52,7 +56,7 @@ public class ArtifactVersionSelectorTest {
 
     @Test
     void last() {
-        assertEquals("400.0.0", ArtifactVersionSelector.last().apply(new DefaultArtifact("g:a:v1"), versions));
+        assertEquals("410.0.0-SNAPSHOT", ArtifactVersionSelector.last().apply(new DefaultArtifact("g:a:v1"), versions));
         assertEquals(
                 "v1", ArtifactVersionSelector.last().apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
     }
@@ -73,7 +77,8 @@ public class ArtifactVersionSelectorTest {
 
     @Test
     void sameMajor() {
-        assertEquals("3.100.0", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:3.0.0"), versions));
+        assertEquals(
+                "3.200.0-SNAPSHOT", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:3.0.0"), versions));
         assertEquals("4.0.0", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:4.0.0"), versions));
         assertEquals(
                 "v1", ArtifactVersionSelector.major().apply(new DefaultArtifact("g:a:v1"), Collections.emptyList()));
@@ -90,7 +95,7 @@ public class ArtifactVersionSelectorTest {
     @Test
     void sameMajorNoPreviews() {
         assertEquals(
-                "3.100.0",
+                "3.200.0-SNAPSHOT",
                 ArtifactVersionSelector.noPreviews(ArtifactVersionSelector.major())
                         .apply(new DefaultArtifact("g:a:3.0.0"), versions));
         assertEquals(
@@ -124,11 +129,11 @@ public class ArtifactVersionSelectorTest {
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "first()")
                         .apply(artifact, versions));
         assertEquals(
-                "400.0.0",
+                "410.0.0-SNAPSHOT",
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "last()")
                         .apply(artifact, versions));
         assertEquals(
-                "3.100.0",
+                "3.200.0-SNAPSHOT",
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "major()")
                         .apply(artifact, versions));
         assertEquals(
@@ -136,7 +141,7 @@ public class ArtifactVersionSelectorTest {
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "minor()")
                         .apply(artifact, versions));
         assertEquals(
-                "3.100.0",
+                "3.200.0-SNAPSHOT",
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "noPreviews(major())")
                         .apply(artifact, versions));
         assertEquals(
@@ -155,5 +160,25 @@ public class ArtifactVersionSelectorTest {
                 "3.100.0",
                 ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "noSnapshotsAndPreviews(major())")
                         .apply(artifact, versions));
+
+        assertEquals(
+                "401.0.0RC",
+                ArtifactVersionSelector.build(
+                                versionScheme, Collections.emptyMap(), "contextualSnapshotsAndPreviews(last())")
+                        .apply(artifact.setVersion("3.0.0-rc-1"), versions));
+        assertEquals(
+                "410.0.0-SNAPSHOT",
+                ArtifactVersionSelector.build(
+                                versionScheme, Collections.emptyMap(), "contextualSnapshotsAndPreviews(last())")
+                        .apply(artifact.setVersion("3.0.0-SNAPSHOT"), versions));
+
+        assertEquals(
+                "3.101.0RC",
+                ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "contextualSnapshotsAndPreviews()")
+                        .apply(artifact.setVersion("3.0.0-rc-1"), versions));
+        assertEquals(
+                "3.200.0-SNAPSHOT",
+                ArtifactVersionSelector.build(versionScheme, Collections.emptyMap(), "contextualSnapshotsAndPreviews()")
+                        .apply(artifact.setVersion("3.0.0-SNAPSHOT"), versions));
     }
 }

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavLibYearMojo.java
@@ -51,23 +51,23 @@ public class GavLibYearMojo extends GavSearchMojoSupport {
     private String boms;
 
     /**
-     * Artifact version matcher spec string to filter version candidates, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string to filter version candidates, default is 'any()'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionMatcherSpec"},
             defaultValue = "noSnapshotsAndPreviews()",
-            description = "Artifact version matcher spec (default 'noSnapshotsAndPreviews()')")
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+            description = "Artifact version matcher spec (default 'any()')")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select "latest", default is 'major()'.
+     * Artifact version selector spec string to select "latest", default is 'contextualSnapshotsAndPreviews()'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "major()",
-            description = "Artifact version selector spec (default 'major()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
+            defaultValue = "contextualSnapshotsAndPreviews()",
+            description = "Artifact version selector spec (default 'contextualSnapshotsAndPreviews()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/gav/GavVersionsMojo.java
@@ -35,23 +35,23 @@ public class GavVersionsMojo extends GavMojoSupport {
     private String gav;
 
     /**
-     * Artifact version matcher spec string to filter version candidates, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string to filter version candidates, default is 'any()'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionMatcherSpec"},
-            defaultValue = "noSnapshotsAndPreviews()",
-            description = "Artifact version matcher spec (default 'noSnapshotsAndPreviews()')")
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+            defaultValue = "any()",
+            description = "Artifact version matcher spec (default 'any()')")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "last()",
-            description = "Artifact version selector spec (default 'last()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+            defaultValue = "contextualSnapshotsAndPreviews()",
+            description = "Artifact version selector spec (default 'contextualSnapshotsAndPreviews()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     @Override

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/hello/HelloMojoSupport.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/hello/HelloMojoSupport.java
@@ -30,23 +30,23 @@ public abstract class HelloMojoSupport extends GavMojoSupport {
     }
 
     /**
-     * Artifact version matcher spec string to filter version candidates for parent, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string to filter version candidates for parent, default is 'any()'.
      */
     @CommandLine.Option(
             names = {"--parentVersionMatcherSpec"},
-            defaultValue = "noSnapshotsAndPreviews()",
-            description = "Artifact version matcher spec for parent (default 'noSnapshotsAndPreviews()')")
-    @Parameter(property = "parentVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+            defaultValue = "any()",
+            description = "Artifact version matcher spec for parent (default 'any()')")
+    @Parameter(property = "parentVersionMatcherSpec", defaultValue = "any()")
     protected String parentVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates for parent, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates for parent, default is 'contextualSnapshotsAndPreviews()'.
      */
     @CommandLine.Option(
             names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "last()",
-            description = "Artifact version selector spec (default 'last()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+            defaultValue = "contextualSnapshotsAndPreviews()",
+            description = "Artifact version selector spec (default 'contextualSnapshotsAndPreviews()')")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     protected String parentVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/CoreExtensionVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/CoreExtensionVersionsMojo.java
@@ -30,15 +30,15 @@ import org.slf4j.LoggerFactory;
 public class CoreExtensionVersionsMojo extends MPMojoSupport {
     private static final Logger log = LoggerFactory.getLogger(CoreExtensionVersionsMojo.class);
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/DependencyVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/DependencyVersionsMojo.java
@@ -33,15 +33,15 @@ public class DependencyVersionsMojo extends MPMojoSupport {
     private String depSpec;
 
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ExtensionVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ExtensionVersionsMojo.java
@@ -20,7 +20,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.version.Version;
-import picocli.CommandLine;
 
 /**
  * Lists available versions of Maven Project extensions.
@@ -34,19 +33,15 @@ public class ExtensionVersionsMojo extends MPPluginMojoSupport {
     private String artifactMatcherSpec;
 
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @CommandLine.Option(
-            names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "last()",
-            description = "Artifact version selector spec (default 'last()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/LibYearMojo.java
@@ -26,15 +26,15 @@ public class LibYearMojo extends MPMojoSupport {
     private String scope;
 
     /**
-     * Artifact version matcher spec string to filter version candidates, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string to filter version candidates, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select "latest", default is 'major()'.
+     * Artifact version selector spec string to select "latest", default is 'contextualSnapshotsAndPreviews()'.
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/ParentVersionsMojo.java
@@ -25,7 +25,6 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.version.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
 
 /**
  * Lists available parents of Maven Project.
@@ -34,19 +33,15 @@ import picocli.CommandLine;
 public class ParentVersionsMojo extends MPPluginMojoSupport {
     private static final Logger log = LoggerFactory.getLogger(ParentVersionsMojo.class);
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @CommandLine.Option(
-            names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "last()",
-            description = "Artifact version selector spec (default 'last()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginLibYearMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginLibYearMojo.java
@@ -15,7 +15,6 @@ import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
 import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
 import eu.maveniverse.maven.toolbox.shared.Result;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
-import java.util.stream.Collectors;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -31,15 +30,15 @@ public class PluginLibYearMojo extends MPPluginMojoSupport {
     private String artifactMatcherSpec;
 
     /**
-     * Artifact version matcher spec string to filter version candidates, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string to filter version candidates, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select "latest", default is 'major()'.
+     * Artifact version selector spec string to select "latest", default is 'contextualSnapshotsAndPreviews()'.
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "major()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**
@@ -64,7 +63,7 @@ public class PluginLibYearMojo extends MPPluginMojoSupport {
                 toolboxCommando.parseArtifactVersionSelectorSpec(artifactVersionSelectorSpec);
         for (ResolutionRoot root : allProjectManagedPluginsAsResolutionRoots(toolboxCommando).stream()
                 .filter(r -> artifactMatcher.test(r.getArtifact()))
-                .collect(Collectors.toList())) {
+                .toList()) {
             toolboxCommando.libYear(
                     "managed plugin " + root.getArtifact(),
                     ResolutionScope.RUNTIME,
@@ -77,7 +76,7 @@ public class PluginLibYearMojo extends MPPluginMojoSupport {
         }
         for (ResolutionRoot root : allProjectPluginsAsResolutionRoots(toolboxCommando).stream()
                 .filter(r -> artifactMatcher.test(r.getArtifact()))
-                .collect(Collectors.toList())) {
+                .toList()) {
             toolboxCommando.libYear(
                     "plugin " + root.getArtifact(),
                     ResolutionScope.RUNTIME,

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginVersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/PluginVersionsMojo.java
@@ -20,7 +20,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.version.Version;
-import picocli.CommandLine;
 
 /**
  * Lists available versions of Maven Project plugins.
@@ -34,19 +33,15 @@ public class PluginVersionsMojo extends MPPluginMojoSupport {
     private String artifactMatcherSpec;
 
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @CommandLine.Option(
-            names = {"--artifactVersionSelectorSpec"},
-            defaultValue = "last()",
-            description = "Artifact version selector spec (default 'last()')")
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**

--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/VersionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/VersionsMojo.java
@@ -36,15 +36,15 @@ import org.eclipse.aether.version.Version;
 @Mojo(name = "versions", threadSafe = true)
 public class VersionsMojo extends MPPluginMojoSupport {
     /**
-     * Artifact version matcher spec string, default is 'noSnapshotsAndPreviews()'.
+     * Artifact version matcher spec string, default is 'any()'.
      */
-    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "noSnapshotsAndPreviews()")
+    @Parameter(property = "artifactVersionMatcherSpec", defaultValue = "any()")
     private String artifactVersionMatcherSpec;
 
     /**
-     * Artifact version selector spec string to select the version from candidates, default is 'last()'.
+     * Artifact version selector spec string to select the version from candidates, default is 'contextualSnapshotsAndPreviews()'.
      */
-    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "last()")
+    @Parameter(property = "artifactVersionSelectorSpec", defaultValue = "contextualSnapshotsAndPreviews()")
     private String artifactVersionSelectorSpec;
 
     /**


### PR DESCRIPTION
All the version selector/matcher combo were wrong (almost, some were ok). The problem: matcher was `noSnapshotsAndPreviews()` and selector was `last()`.

New setup: matcher is `any()` and selector is `contextualSnapshotsAndPreviews()`

The new selector is now selecting based on initial state:
* IF initial state is snapshot version, no filtering applied
* IF initial state is preview version, filters out snaphots
* IF initial state is not preview nor snapshot, noPreviewAndSnapshot() is applied

The new selector accepts 0..1 arguments, with 0 arg defaults to `major()` selector, but with 1 argument it may be further customized.