### PR TITLE
Add tree-dd mojo

### DIFF
--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/TreeDDMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/TreeDDMojo.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.toolbox.plugin.mp;
+
+import eu.maveniverse.maven.toolbox.plugin.MPMojoSupport;
+import eu.maveniverse.maven.toolbox.shared.ResolutionRoot;
+import eu.maveniverse.maven.toolbox.shared.ResolutionScope;
+import eu.maveniverse.maven.toolbox.shared.Result;
+import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import java.util.List;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.Dependency;
+
+/**
+ * Displays dependency tree of Maven Project if it would be a direct dependency of some project.
+ */
+@Mojo(name = "tree-dd", threadSafe = true)
+public class TreeDDMojo extends MPMojoSupport {
+    /**
+     * The resolution scope to display, accepted values are "runtime", "compile", "test", etc.
+     */
+    @Parameter(property = "scope", defaultValue = "runtime", required = true)
+    private String scope;
+
+    /**
+     * The dependency scope to put project in, accepted values are "runtime", "compile", "test", etc.
+     */
+    @Parameter(property = "dependencyScope", defaultValue = "compile", required = true)
+    private String dependencyScope;
+
+    /**
+     * The dependency matcher if you want to filter as eager as Lenny wants.
+     */
+    @Parameter(property = "dependencyMatcher", defaultValue = "any()", required = true)
+    private String dependencyMatcher;
+
+    /**
+     * Set it {@code true} for verbose tree.
+     */
+    @Parameter(property = "verboseTree", defaultValue = "false", required = true)
+    private boolean verboseTree;
+
+    /**
+     * Set it {@code true} for verbose tree nodes.
+     */
+    @Parameter(property = "verboseTreeNode", defaultValue = "false", required = true)
+    private boolean verboseTreeNode;
+
+    @Override
+    protected Result<CollectResult> doExecute() throws Exception {
+        ToolboxCommando toolboxCommando = getToolboxCommando();
+        ResolutionRoot root = ResolutionRoot.ofNotLoaded(new DefaultArtifact("org.example:some-project:1.0.0"))
+                .withDependencies(
+                        List.of(new Dependency(projectAsResolutionRoot().getArtifact(), dependencyScope)))
+                .build();
+        return toolboxCommando.tree(
+                ResolutionScope.parse(scope),
+                root,
+                verboseTree,
+                verboseTreeNode,
+                toolboxCommando.parseDependencyMatcherSpec(dependencyMatcher));
+    }
+}


### PR DESCRIPTION
That is like tree, but shows the tree "if current project would be a direct dependency of some other project".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Maven plugin goal (`tree-dd`) to render dependency trees with configurable options for resolution scope, dependency scope, dependency matching, and output verbosity levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/toolbox/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->