### PR TITLE
Bugfix: check-exclusions mojo

### DIFF
--- a/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/CheckExclusionsMojo.java
+++ b/toolbox/src/main/java/eu/maveniverse/maven/toolbox/plugin/mp/CheckExclusionsMojo.java
@@ -39,7 +39,7 @@ public class CheckExclusionsMojo extends MPPluginMojoSupport {
         for (Dependency dependency : project.getDependencies()) {
             for (Exclusion exclusion : dependency.getExclusions()) {
                 ResolutionRoot dependencyRoot = ResolutionRoot.ofNotLoaded(project.getArtifact())
-                        .withDependencies(List.of(dependency))
+                        .withDependencies(List.of(dependency.setExclusions(null)))
                         .build();
                 getOutput()
                         .marker(Output.Verbosity.NORMAL)


### PR DESCRIPTION
Did not nullify exclusions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency exclusion handling to correctly process Maven dependencies with exclusions when locating runtime artifacts. The tool now properly isolates excluded dependencies during validation instead of including their metadata in the matching process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/toolbox/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->