### PR TITLE
Add artifact sink generating module-uri properties

### DIFF
--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -119,12 +119,13 @@ public final class ArtifactSinks {
                     break;
                 }
                 case "modules": {
-                    if (node.getChildren().isEmpty()) {
-                        throw new IllegalArgumentException("modules requires at least 1 argument: the output file");
+                    if (node.getChildren().isEmpty() || node.getChildren().size() > 2) {
+                        String syntax = "modules(<file>[,<classifier>])";
+                        throw new IllegalArgumentException("modules accepts 1..2 arguments: " + syntax);
                     }
                     Path file = tc.basedir().resolve(node.getChildren().get(0).getValue());
                     String classifier = "";
-                    if (node.getChildren().size() > 1) {
+                    if (node.getChildren().size() == 2) {
                         classifier = node.getChildren().get(1).getValue();
                     }
                     params.add(modulePropertiesArtifactSink(file, classifier, tc.output(), tc));

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -84,6 +84,7 @@ public final class ArtifactSinks {
                     && !"flat".equals(node.getValue())
                     && !"matching".equals(node.getValue())
                     && !"mapping".equals(node.getValue())
+                    && !"modules".equals(node.getValue())
                     && !"unpack".equals(node.getValue());
         }
 
@@ -114,6 +115,14 @@ public final class ArtifactSinks {
                         throw new IllegalArgumentException("op artifactUri accepts only 0..1 argument");
                     }
                     params.add(artifactUriSink(tc.output, tc, dumpOnClose));
+                    break;
+                }
+                case "modules": {
+                    if (node.getChildren().size() != 1) {
+                        throw new IllegalArgumentException("modules requires 1 argument: output file");
+                    }
+                    Path file = tc.basedir().resolve(node.getChildren().get(0).getValue());
+                    params.add(modulePropertiesArtifactSink(file, tc.output(), tc));
                     break;
                 }
                 case "stat": {
@@ -559,6 +568,72 @@ public final class ArtifactSinks {
             for (Sink<Artifact> sink : artifactSinks) {
                 sink.close();
             }
+        }
+    }
+
+    /**
+     * Create a "module properties" artifact sink for printing a module-url map.
+     */
+    public static ModulePropertiesArtifactSink modulePropertiesArtifactSink(
+            Path file, Output output, ToolboxCommando tc) {
+        return new ModulePropertiesArtifactSink(file, output, tc);
+    }
+
+    public static class ModulePropertiesArtifactSink implements Artifacts.Sink {
+        record Property(String module, URI origin, long size, String sha1) {
+            String toLine() {
+                return "%s=%s#SIZE=%d&SHA-1=%s".formatted(module, origin, size, sha1);
+            }
+        }
+
+        private final Path file;
+        private final Output output;
+        private final Map<String, Property> propertyByModuleName;
+        private final ModuleDescriptorExtractingSink moduleArtifactSink;
+        private final ChecksumArtifactSink checksumArtifactSink;
+        private final ArtifactUriSink artifactUriSink;
+
+        private ModulePropertiesArtifactSink(Path file, Output output, ToolboxCommando tc) {
+            this.file = file;
+            this.output = output;
+            this.propertyByModuleName = new ConcurrentHashMap<>();
+            this.moduleArtifactSink = new ModuleDescriptorExtractingSink(output);
+            this.checksumArtifactSink = checksumArtifactSink();
+            this.artifactUriSink = artifactUriSink(output, tc, false);
+        }
+
+        @Override
+        public void accept(Artifact artifact) throws IOException {
+            var file = artifact.getFile();
+            if (file == null) return;
+            var path = file.toPath();
+            if (!path.getFileName().toString().endsWith(".jar")) return;
+            if (!Files.exists(path)) return;
+
+            moduleArtifactSink.accept(artifact);
+            artifactUriSink.accept(artifact);
+            checksumArtifactSink.accept(artifact);
+
+            String module = moduleArtifactSink.getModuleDescriptor(artifact).name();
+            URI origin = artifactUriSink.getUri(artifact);
+            long size = Files.size(path);
+            String sha1 = checksumArtifactSink.checksums(artifact).get("SHA-1");
+            propertyByModuleName.put(module, new Property(module, origin, size, sha1));
+        }
+
+        @Override
+        public void close() throws Exception {
+            List<String> lines = propertyByModuleName.keySet().stream()
+                    .sorted()
+                    .map(propertyByModuleName::get)
+                    .map(Property::toLine)
+                    .toList();
+            Files.write(file, lines);
+            output.tell("Found {} distinct modules", lines.size());
+            lines.forEach(output::tell);
+            output.tell("------------------------------");
+            output.tell("Module properties written to: {}", file.toUri());
+            output.tell("------------------------------");
         }
     }
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -628,6 +628,8 @@ public final class ArtifactSinks {
                     .map(propertyByModuleName::get)
                     .map(Property::toLine)
                     .toList();
+            Path parent = file.toAbsolutePath().getParent();
+            if (parent != null) Files.createDirectories(parent);
             Files.write(file, lines);
             output.tell("Found {} distinct modules", lines.size());
             lines.forEach(output::tell);

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -739,8 +739,7 @@ public final class ArtifactSinks {
                 for (Artifact artifact : seen) {
                     output.tell("{}{}", indent, artifact);
                     if (details) {
-                        ModuleDescriptor descriptor =
-                                moduleDescriptorExtractingSink.getModuleDescriptor(artifact);
+                        ModuleDescriptor descriptor = moduleDescriptorExtractingSink.getModuleDescriptor(artifact);
                         String moduleInfo = "";
                         if (descriptor != null) {
                             moduleInfo = moduleDescriptorExtractingSink.formatString(descriptor);

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -16,6 +16,7 @@ import eu.maveniverse.maven.toolbox.shared.ArtifactMatcher;
 import eu.maveniverse.maven.toolbox.shared.ArtifactNameMapper;
 import eu.maveniverse.maven.toolbox.shared.Sink;
 import eu.maveniverse.maven.toolbox.shared.ToolboxCommando;
+import eu.maveniverse.maven.toolbox.shared.internal.ModuleDescriptorExtractingSink.ModuleDescriptor;
 import eu.maveniverse.maven.toolbox.shared.output.Output;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -611,14 +612,26 @@ public final class ArtifactSinks {
             if (!Files.exists(path)) return;
 
             moduleArtifactSink.accept(artifact);
+            ModuleDescriptor module = moduleArtifactSink.getModuleDescriptor(artifact);
+            if (!module.available()) {
+                output.tell("No module available, skipping artifact: {}", artifact);
+                return;
+            }
             artifactUriSink.accept(artifact);
-            checksumArtifactSink.accept(artifact);
-
-            String module = moduleArtifactSink.getModuleDescriptor(artifact).name();
             URI origin = artifactUriSink.getUri(artifact);
-            long size = Files.size(path);
+            if (origin == null) {
+                output.tell("No origin uri found, skipping artifact: {}", artifact);
+                return;
+            }
+            checksumArtifactSink.accept(artifact);
             String sha1 = checksumArtifactSink.checksums(artifact).get("SHA-1");
-            propertyByModuleName.put(module, new Property(module, origin, size, sha1));
+            if (sha1 == null) {
+                output.tell("No SHA-1 checksum, skipping artifact: {}", artifact);
+                return;
+            }
+            String name = module.name();
+            long size = Files.size(path);
+            propertyByModuleName.put(name, new Property(name, origin, size, sha1));
         }
 
         @Override
@@ -726,7 +739,7 @@ public final class ArtifactSinks {
                 for (Artifact artifact : seen) {
                     output.tell("{}{}", indent, artifact);
                     if (details) {
-                        ModuleDescriptorExtractingSink.ModuleDescriptor descriptor =
+                        ModuleDescriptor descriptor =
                                 moduleDescriptorExtractingSink.getModuleDescriptor(artifact);
                         String moduleInfo = "";
                         if (descriptor != null) {

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -589,7 +589,8 @@ public final class ArtifactSinks {
     public static class ModulePropertiesArtifactSink implements Artifacts.Sink {
         record Property(String module, URI origin, long size, String sha1) {
             String toLine() {
-                return "%s=%s#SIZE=%d&SHA-1=%s".formatted(module, origin, size, sha1);
+                URI value = URI.create(origin.toString() + "#SIZE=%d&SHA-1=%s".formatted(size, sha1));
+                return "%s=%s".formatted(module, value.toASCIIString());
             }
         }
 

--- a/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
+++ b/shared/src/main/java/eu/maveniverse/maven/toolbox/shared/internal/ArtifactSinks.java
@@ -119,11 +119,16 @@ public final class ArtifactSinks {
                     break;
                 }
                 case "modules": {
-                    if (node.getChildren().size() != 1) {
-                        throw new IllegalArgumentException("modules requires 1 argument: output file");
+                    if (node.getChildren().isEmpty()) {
+                        throw new IllegalArgumentException("modules requires at least 1 argument: the output file");
                     }
                     Path file = tc.basedir().resolve(node.getChildren().get(0).getValue());
-                    params.add(modulePropertiesArtifactSink(file, tc.output(), tc));
+                    String classifier = "";
+                    if (node.getChildren().size() > 1) {
+                        classifier = node.getChildren().get(1).getValue();
+                    }
+                    params.add(modulePropertiesArtifactSink(file, classifier, tc.output(), tc));
+                    node.getChildren().clear();
                     break;
                 }
                 case "stat": {
@@ -576,8 +581,8 @@ public final class ArtifactSinks {
      * Create a "module properties" artifact sink for printing a module-url map.
      */
     public static ModulePropertiesArtifactSink modulePropertiesArtifactSink(
-            Path file, Output output, ToolboxCommando tc) {
-        return new ModulePropertiesArtifactSink(file, output, tc);
+            Path file, String classifier, Output output, ToolboxCommando tc) {
+        return new ModulePropertiesArtifactSink(file, classifier, output, tc);
     }
 
     public static class ModulePropertiesArtifactSink implements Artifacts.Sink {
@@ -588,14 +593,16 @@ public final class ArtifactSinks {
         }
 
         private final Path file;
+        private final String classifier;
         private final Output output;
         private final Map<String, Property> propertyByModuleName;
         private final ModuleDescriptorExtractingSink moduleArtifactSink;
         private final ChecksumArtifactSink checksumArtifactSink;
         private final ArtifactUriSink artifactUriSink;
 
-        private ModulePropertiesArtifactSink(Path file, Output output, ToolboxCommando tc) {
+        private ModulePropertiesArtifactSink(Path file, String classifier, Output output, ToolboxCommando tc) {
             this.file = file;
+            this.classifier = classifier;
             this.output = output;
             this.propertyByModuleName = new ConcurrentHashMap<>();
             this.moduleArtifactSink = new ModuleDescriptorExtractingSink(output);
@@ -605,24 +612,30 @@ public final class ArtifactSinks {
 
         @Override
         public void accept(Artifact artifact) throws IOException {
+            // only interesting in Java Archives
+            if (!"jar".equals(artifact.getExtension())) return;
+            // only interested in specific non-empty classifier?
+            if (!classifier.isEmpty() && !classifier.equals(artifact.getClassifier())) return;
+            // only interested in resolved files.
             var file = artifact.getFile();
             if (file == null) return;
             var path = file.toPath();
-            if (!path.getFileName().toString().endsWith(".jar")) return;
             if (!Files.exists(path)) return;
-
+            // only interested in modular Java Archives
             moduleArtifactSink.accept(artifact);
             ModuleDescriptor module = moduleArtifactSink.getModuleDescriptor(artifact);
             if (!module.available()) {
                 output.tell("No module available, skipping artifact: {}", artifact);
                 return;
             }
+            // only interested in artifacts with origin URIs
             artifactUriSink.accept(artifact);
             URI origin = artifactUriSink.getUri(artifact);
             if (origin == null) {
                 output.tell("No origin uri found, skipping artifact: {}", artifact);
                 return;
             }
+            // only interested in artifacts with SHA-1 checksums
             checksumArtifactSink.accept(artifact);
             String sha1 = checksumArtifactSink.checksums(artifact).get("SHA-1");
             if (sha1 == null) {


### PR DESCRIPTION
This change adds an artifact sink that prints and generates a `.properties` file with modul-uri entries.

Usage example:

```shell
java -jar toolbox-0.15.13-SNAPSHOT-cli.jar
  copy-transitive
  --boms org.junit:junit-bom:6.1.0
  modules(junit-6.1.0-modules.properties)
  org.junit.jupiter:junit-jupiter,org.junit:junit-start
```

Yields:

```properties
Copied 23 artifacts
Found 14 distinct modules
org.apiguardian.api=https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar#SIZE=6806&SHA-1=a231e0d844d2721b0fa1b238006d15c6ded6842a
org.jspecify=https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar#SIZE=3819&SHA-1=7425a601c1c7ec76645a78d22b8c6a627edee507
org.junit.jupiter=https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/6.1.0/junit-jupiter-6.1.0.jar#SIZE=6375&SHA-1=52aef21f8c9fa491ff7eb20008e39102a8479f79
org.junit.jupiter.api=https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/6.1.0/junit-jupiter-api-6.1.0.jar#SIZE=312240&SHA-1=5376d10370f32af4f3b1b7a378906ee58dcdacb3
org.junit.jupiter.engine=https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/6.1.0/junit-jupiter-engine-6.1.0.jar#SIZE=352590&SHA-1=82414ee1a0308d2f096c37d317b93b66c13dbb9a
org.junit.jupiter.params=https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/6.1.0/junit-jupiter-params-6.1.0.jar#SIZE=303146&SHA-1=6e6dcbd963a6c16217350535a640e1c0fde0d619
org.junit.platform.commons=https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/6.1.0/junit-platform-commons-6.1.0.jar#SIZE=175866&SHA-1=03bb0447338b81f4396648c406d3e1c22f65f689
org.junit.platform.console=https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-console/6.1.0/junit-platform-console-6.1.0.jar#SIZE=562445&SHA-1=b4785a1945051b8f5fa2daa82b72ea0f7188c47e
org.junit.platform.engine=https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/6.1.0/junit-platform-engine-6.1.0.jar#SIZE=323857&SHA-1=754271e8493a0be2838f3500b30971969b8603d0
org.junit.platform.launcher=https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/6.1.0/junit-platform-launcher-6.1.0.jar#SIZE=251171&SHA-1=78124de837a3e0b9e4e32a2c80ba47117f7f8c60
org.junit.platform.reporting=https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-reporting/6.1.0/junit-platform-reporting-6.1.0.jar#SIZE=153927&SHA-1=914dbb41a35cf269e575037eca4b201bd5a803bb
org.junit.start=https://repo.maven.apache.org/maven2/org/junit/junit-start/6.1.0/junit-start-6.1.0.jar#SIZE=9579&SHA-1=80f80607ff0ddfc33353f1bcd4ecba11f9c250f7
org.opentest4j=https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar#SIZE=14304&SHA-1=152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e
org.opentest4j.reporting.tooling.spi=https://repo.maven.apache.org/maven2/org/opentest4j/reporting/open-test-reporting-tooling-spi/0.2.5/open-test-reporting-tooling-spi-0.2.5.jar#SIZE=45871&SHA-1=92a64a32e3fbdfc094d05a714d88c619c0d12f38
------------------------------
Module properties written to: file:///.../junit-6.1.0-modules.properties
------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `modules` operation that writes per-module property files for modular JARs (requires an output path, optional classifier). Each line maps module name to origin URI, file size and SHA-1; non-modular artifacts are skipped. Output is sorted and a completion summary is emitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/toolbox/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->